### PR TITLE
GH Action workflow to start performance test with slsart

### DIFF
--- a/.github/workflows/performancetest.yml
+++ b/.github/workflows/performancetest.yml
@@ -1,0 +1,40 @@
+name: Performance-Test
+
+on:  
+  push:
+    branches:
+      - development
+
+jobs:
+  slsart-perf:
+    name: slsart Performance Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    env:
+      NPM_CONFIG_PREFIX: "~/.npm-global"
+      STAGE_NAME: merge-perf-test
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-2
+      - run: npm install -g serverless@1.38.0
+      - run: npm install -g serverless-artillery
+      # once a folder with slsart script.yml and serverless.yml are created and in the repo
+      # we can copy them into the working dir to run those specific tests with those configurations
+      # - currently this just runs the defaults
+      # examples for future:
+      # - run: cp ./slsart/script.yml ./
+      # - run: cp ./slsart/serverless.yml ./
+      - run: ~/.npm-global/bin/slsart deploy --stage $STAGE_NAME
+      - run: ~/.npm-global/bin/slsart invoke --stage $STAGE_NAME
+      - run: ~/.npm-global/bin/slsart remove --stage $STAGE_NAME

--- a/.github/workflows/performancetest.yml
+++ b/.github/workflows/performancetest.yml
@@ -27,14 +27,15 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-      - run: npm install -g serverless@1.38.0
-      - run: npm install -g serverless-artillery
+      - run: |
+          npm install -g serverless@1.38.0 serverless-artillery
       # once a folder with slsart script.yml and serverless.yml are created and in the repo
       # we can copy them into the working dir to run those specific tests with those configurations
       # - currently this just runs the defaults
       # examples for future:
       # - run: cp ./slsart/script.yml ./
       # - run: cp ./slsart/serverless.yml ./
-      - run: ~/.npm-global/bin/slsart deploy --stage $STAGE_NAME
-      - run: ~/.npm-global/bin/slsart invoke --stage $STAGE_NAME
-      - run: ~/.npm-global/bin/slsart remove --stage $STAGE_NAME
+      - run: |
+          ~/.npm-global/bin/slsart deploy --stage $STAGE_NAME
+          ~/.npm-global/bin/slsart invoke --stage $STAGE_NAME
+          ~/.npm-global/bin/slsart remove --stage $STAGE_NAME

--- a/.github/workflows/performancetest.yml
+++ b/.github/workflows/performancetest.yml
@@ -9,25 +9,25 @@ jobs:
   slsart-perf:
     name: slsart Performance Test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
     env:
       NPM_CONFIG_PREFIX: "~/.npm-global"
       STAGE_NAME: merge-perf-test
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '14'
+          check-latest: true
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
-      - run: |
+      - name: Install serverless and serverless-artillery
+        run: |
           npm install -g serverless@1.38.0 serverless-artillery
       # once a folder with slsart script.yml and serverless.yml are created and in the repo
       # we can copy them into the working dir to run those specific tests with those configurations
@@ -35,7 +35,8 @@ jobs:
       # examples for future:
       # - run: cp ./slsart/script.yml ./
       # - run: cp ./slsart/serverless.yml ./
-      - run: |
+      - name: Deploy, invoke, remove functions
+        run: |
           ~/.npm-global/bin/slsart deploy --stage $STAGE_NAME
           ~/.npm-global/bin/slsart invoke --stage $STAGE_NAME
           ~/.npm-global/bin/slsart remove --stage $STAGE_NAME


### PR DESCRIPTION
Closes #5 - Team 3 Task 7

# GH Action to start slsart performance test
- This GH Actions workflow will trigger whenever a pull request is merged into the development branch.
- GH Actions Workflow:
     - First it will create a environment with the latest Ubuntu
     - Next it will pull in the checkout code and set up Node
     - Then it will set up the AWS credentials to be used by Serverless-Artillery
          - In the github secrets area under settings, there will be 2 secrets
               - AWS_ACCESS_KEY_ID
               - AWS_SECRET_ACCESS_KEY
               - If this is your own forked repo, you will need to add these to your forked repo's secrets
     - It will then install Serverless version 1.38.0 (slsart doesn't work with the newest version)
     - Then it will install Serverless-Artillery
     - Finally it will deploy the functions, invoke them, then remove them
     - You can see this happening under the Actions tab of the repo
- Since we do not have an actual performance test to run, it just uses the default ones they use as an example
- When the script.yml is created for the actual performance test that eventually will want to be triggered, it can be placed in a slsart folder. Same with custom serverless.yml file that has the functions and AWS information that will be used.
     - When those yml's are created, lines 36 and 37 show examples of how you would put the steps in to use those instead of the default
     
Here is a completed action from my fork, where you can see what a fully finished and successful job would look like:
https://github.com/zxkevinxz/ad440-winter2021-thursday-repo/runs/1706988171?check_suite_focus=true

|**DATE**|**ACTIVITY**|**TIME**|
|---|:---|:---|
|1/12|Research slsart and GH actions|4 hours|
|1/14|Prototyping and testing GHA with slsart|4 hours|
|1/14|Small updates and cleanup|1 hour|