### PR TITLE
Should fix a bug caused by incorrect file paths

### DIFF
--- a/.github/workflows/deployAzureFunctions.yaml
+++ b/.github/workflows/deployAzureFunctions.yaml
@@ -6,7 +6,7 @@ on:
       - development
 
 env:
-  AZURE_FUNCTIONAPP_PACKAGE_PATH: './functions'   # relative to the root, where are you keeping the functions
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: 'functions'   # relative to the root, where are you keeping the functions
   PYTHON_VERSION: '3.8'                 # the version of python we are using
 
 jobs:


### PR DESCRIPTION
I don't know why this worked on my branch but this change should fix a problem caused by merging the previous PR. For the record, the bug is caused because the file path for the functions was assigned as `./functions` and later on, the file path to deploy from is `./{functions file path}` which ends up being `././functions`. It's an obvious bug in retrospect! I can't believe I missed it! 