### PR TITLE
[BUG] users/userId/tasks/taskId API logging and error handling Issue #83

### DIFF
--- a/functions/HttpTriggerAPIUsersIdTaskId/__init__.py
+++ b/functions/HttpTriggerAPIUsersIdTaskId/__init__.py
@@ -1,3 +1,5 @@
+"""This sript runs the userId/taskId API endpoint functionality and consists of
+    the main function, ODBC conenct function and 4 CRUD methods functions"""
 import logging
 import os
 import pyodbc
@@ -27,16 +29,7 @@ def get(param1, param2):
         cnxn.close()
         logging.info('Closed the connection')
 
-#POST API method function       
-def post(param):
-    return ('You selected POST method with {param} values. Functionality under construction')
-            # STARTER CODE FOR NEXT SPRINT, SQL QUERY TESTED
-            #     #insert row into tasks table / create a new task
-            #     #createdDate #'20120618 10:34:09 AM' and title/description are hardcoded for sprint1, update with automated date stamp and url params later
-            #     sql_query = ("""INSERT INTO dbo.tasks (userId, title, description, createdDate)
-            #     VALUES (?, ?, ?, '20120618 10:34:09 AM')""")
-            #     cursor.execute(sql_query, userId, 'Do It', 'Almost like Nike motto')   
-            #     logging.info('Executed the query')
+#POST API method function not implemented     
 
 #UPDATE API method function
 def update(param1, param2):
@@ -99,8 +92,8 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     logging.info('Python HTTP trigger function processed a request.')
 
 #collects parameters passed in url        
-    userId = req.params.get('userId')
-    taskId = req.params.get('taskId')
+    userId = req.route_params.get('userId')
+    taskId = req.route_params.get('taskId')
     logging.info('Trying to get userId and taskId')
     if (not userId) and (not taskId):
         logging.info("Got neither userId nor taskId")
@@ -125,11 +118,6 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
         if method == "GET":        
             getResult = get(userId, taskId)
             return func.HttpResponse(f"This {method} method was called. You entered {userId} as userId and {taskId} as taskId. Result: {getResult}")
-
-    #if POST method is selected, it executes here
-        if method == "POST":
-            postResult = post(method)
-            return func.HttpResponse(f"Temp results: {postResult}")
 
     #if UPDATE method is selected, it executes here
         if method == "UPDATE":

--- a/functions/HttpTriggerAPIUsersIdTaskId/__init__.py
+++ b/functions/HttpTriggerAPIUsersIdTaskId/__init__.py
@@ -1,4 +1,4 @@
-"""This sript runs the userId/taskId API endpoint functionality and consists of
+"""This script runs the userId/taskId API endpoint functionality and consists of
     the main function, ODBC conenct function and 4 CRUD methods functions"""
 import json
 from datetime import datetime
@@ -8,27 +8,29 @@ import pyodbc
 import azure.functions as func
 
 #GET API method function
-def get(param1, param2):
+def get(userId, taskId):
     #connects to db
-    logging.debug('Attempting a db conenction')
-    cnxn = connect()
-    cursor = cnxn.cursor() 
+
     try:
+        logging.debug('Attempting a db connection')
+        cnxn = connect()
+        cursor = cnxn.cursor() 
         logging.debug('opened connection')        
-        logging.debug('Attempting to execute GET task query')
+        logging.debug(f'Attempting to execute GET task query for task {taskId}')
         #Get task title, description and user name by userId and taskId
-        sql_query = ("""SELECT tasks.title, tasks.description, tasks.createdDate, tasks.dueDate, 
-                    tasks.completed, tasks.completedDate, CONCAT (users.firstName, ' ', users.lastName) AS "user" 
+        sql_query = ("""SELECT tasks.userId, CONCAT (users.firstName, ' ', users.lastName) AS "user",
+                    tasks.taskId, tasks.title, tasks.description, tasks.createdDate, tasks.dueDate, 
+                    tasks.completed, tasks.completedDate 
                     FROM [dbo].[tasks] JOIN [dbo].[users] 
                     on [dbo].[tasks].userId = [dbo].[users].userId
                     WHERE [dbo].[users].userId = ? AND [dbo].[tasks].taskId = ?""")
-        cursor.execute(sql_query, param1, param2)
-        logging.debug('Executed the query')          
+        cursor.execute(sql_query, userId, taskId)
+        logging.debug(f'Executed the GET query for {taskId}')          
         row = cursor.fetchone()
-        logging.info(f"Got result: {row}")
+        logging.debug(f"Got result: {row}")
         if not row:
             logging.error('No record with the requested parameters')
-            return func.HttpResponse('Task not found', status_code=500)
+            return func.HttpResponse('Task not found', status_code=404)
         else:
             columns = [column[0] for column in cursor.description]
             data = dict(zip(columns, row))
@@ -36,41 +38,90 @@ def get(param1, param2):
     finally:
         cursor.close()
         cnxn.close()
-        logging.info('Closed the db connection')   
+        logging.debug('Closed the db connection')   
+
+# #Parses JSON body received by the API
+# def parse(task_req_body):
+#        try:
+#             #assert for the presense of appropriate fields in JSON
+#             assert 'title' in task_req_body, "New task request body did not contain field: 'title'"
+#             assert 'description' in task_req_body, "New task request body did not contain field: 'description'"
+#             assert 'dueDate' in task_req_body, "New user request body did not contain field: 'dueDate'"
+#             assert 'completed' in task_req_body, "New user request body did not contain field: 'completed'
+#             assert 'completedDate' in task_req_body, "New user request body did not contain field: 'completedDate'"
+#         except AssertionError as task_req_body_content_error:
+#             logging.error('New user request body did not contain fields to update a task')
+#             return func.HttpResponse(task_req_body_content_error.args[0], status_code=400)
+#         logging.debug('New user request body contained necessary fields to update a task')  
+#         # Unpack task data
+#         title = task_req_body.get('title')
+#         description = task_req_body.get('description')
+#         dueDate = None
+#         if task_req_body.get('dueDate') != None:
+#             dueDate = datetime.strptime(task_req_body.get('dueDate'), '%d/%m/%y %H:%M:%S')  
+#         completed = task_req_body.get('completed')
+#         completedDate = datetime.strptime(task_req_body.get('completedDate'), '%d/%m/%y %H:%M:%S')      
+#         # update task: title and description
+#         sql_query = """UPDATE [dbo].[tasks]
+#             SET title = ?, description = ?, dueDate = ?, completed = ?, completedDate = ?
+#             WHERE userId = ? AND taskId = ?"""
+#         try:
+#             rowcount = cursor.execute(sql_query, title, description, dueDate, completed, completedDate, userId, taskId).rowcount
+#             if not rowcount:
+#                 logging.error('No record with the requested parameters exists in db')
+#                 return func.HttpResponse('No record to update', status_code=404)                
+#             logging.debug('UPDATE query executed')
+#             logging.debug(f"Executed the query: {rowcount} rows affected for taskId {taskId}")
+#             return func.HttpResponse(status_code=200)
+#         except Exception as e:
+#             logging.critical('Unable to execute the query')
+#             return func.HttpResponse("Error: %s" % str(e), status_code=400)
+#     finally:  
 
 #PUT API method function
-def update(param1, param2, task_req_body):
+def update(userId, taskId, task_req_body):
     #connects to db
     cnxn = connect()
     cursor = cnxn.cursor()
     try:
-        logging.info('opened connection')        
-        logging.info('Going to execute UPDATE task query')
+        logging.debug('opened connection')        
+        logging.debug(f'Going to execute UPDATE task {taskId} for user {userId} query')
         # task_req_body input check
         logging.debug("Checking the request body for necessary fields to update a task")
+###HOW to ENSURE NOTHING IS WRONG WITH JSON (see code in main and move if reasonable)
+###parse JSON in a separate file and validate there, pass the dictionary to this function
         try:
+            #assert for the presense of appropriate fields in JSON
             assert 'title' in task_req_body, "New task request body did not contain field: 'title'"
             assert 'description' in task_req_body, "New task request body did not contain field: 'description'"
             assert 'dueDate' in task_req_body, "New user request body did not contain field: 'dueDate'"
+            assert 'completed' in task_req_body, "New user request body did not contain field: 'completed'"
+            assert 'completedDate' in task_req_body, "New user request body did not contain field: 'completedDate'"
         except AssertionError as task_req_body_content_error:
-            logging.critical('New user request body did not contain fields to update a task')
+            logging.error('New user request body did not contain fields to update a task')
             return func.HttpResponse(task_req_body_content_error.args[0], status_code=400)
-        logging.info('New user request body contained necessary fields to update a task')  
+        logging.debug('New user request body contained necessary fields to update a task')  
         # Unpack task data
         title = task_req_body.get('title')
         description = task_req_body.get('description')
-        dueDate = datetime.strptime(task_req_body.get('dueDate'), '%d/%m/%y %H:%M:%S')     
+        dueDate = None
+        if task_req_body.get('dueDate') != None:
+            dueDate = datetime.strptime(task_req_body.get('dueDate'), '%d/%m/%y %H:%M:%S')  
+        completed = task_req_body.get('completed')
+        completedDate = None
+        if task_req_body.get('completedDate') != None:
+            completedDate = datetime.strptime(task_req_body.get('completedDate'), '%d/%m/%y %H:%M:%S')      
         # update task: title and description
         sql_query = """UPDATE [dbo].[tasks]
-        SET title = '{}', description = '{}', dueDate = '{}'
-        WHERE userId = ? AND taskId = ?""".format(title, description, dueDate)
+            SET title = ?, description = ?, dueDate = ?, completed = ?, completedDate = ?
+            WHERE userId = ? AND taskId = ?"""
         try:
-            rowcount = cursor.execute(sql_query, param1, param2).rowcount
+            rowcount = cursor.execute(sql_query, title, description, dueDate, completed, completedDate, userId, taskId).rowcount
             if not rowcount:
                 logging.error('No record with the requested parameters exists in db')
-                return func.HttpResponse('No record to update', status_code=500)                
+                return func.HttpResponse('No record to update', status_code=404)                
             logging.debug('UPDATE query executed')
-            logging.info(f"Executed the query: {rowcount} rows affected for taskId {param2}")
+            logging.debug(f"Executed the query: {rowcount} rows affected for taskId {taskId}")
             return func.HttpResponse(status_code=200)
         except Exception as e:
             logging.critical('Unable to execute the query')
@@ -81,43 +132,26 @@ def update(param1, param2, task_req_body):
         #properly closes the connection
         cursor.close()
         cnxn.close()
-        logging.info('Closed the db connection')    
+        logging.debug('Closed the db connection')    
 
 #DELETE API method function
-def delete(param1, param2):
+def delete(userId, taskId):
     #connects to db
     cnxn = connect()
     cursor = cnxn.cursor()
     try:
-        logging.info('opened connection')        
-        logging.info('Going to execute DELETE task query')
-        # # task_req_body input check
-        # logging.debug("Checking the request body for necessary fields to update a task")
-        # try:
-        #     assert 'title' in task_req_body, "New task request body did not contain field: 'title'"
-        #     assert 'description' in task_req_body, "New task request body did not contain field: 'description'"
-        #     assert 'dueDate' in task_req_body, "New user request body did not contain field: 'dueDate'"
-        # except AssertionError as task_req_body_content_error:
-        #     logging.critical('New user request body did not contain fields to update a task')
-        #     return func.HttpResponse(task_req_body_content_error.args[0], status_code=400)
-        # logging.info('New user request body contained necessary fields to update a task')  
-        # # Unpack task data
-        # title = task_req_body.get('title')
-        # description = task_req_body.get('description')
-        # dueDate = datetime.strptime(task_req_body.get('dueDate'), '%d/%m/%y %H:%M:%S')     
-
-        # #delete row, client passes in userId and taskId
+        logging.debug('opened connection')        
+        logging.debug(f'Going to execute DELETE task {taskId} for user {userId} query')
         sql_query = ("""DELETE FROM [dbo].[tasks] WHERE userId = ? AND taskId = ?""")
         try:
-            rowcount = cursor.execute(sql_query, param1, param2).rowcount
+            rowcount = cursor.execute(sql_query, userId, taskId).rowcount
             if not rowcount:
                 logging.error('No record with the requested parameters exists in db')
-                return func.HttpResponse('No record to delete', status_code=500)                
-            logging.debug('Executed the DELETE task query')
-            logging.info(f"Executed the query: {rowcount} rows affected for taskId {param2}")
+                return func.HttpResponse('No record to delete', status_code=404)                
+            logging.debug(f"Executed the DELETE query: {rowcount} rows affected for taskId {taskId}")
             return func.HttpResponse(status_code=200)
         except Exception as e:
-            logging.critical('Unable to execute the query')
+            logging.error('Unable to execute the query')
             return func.HttpResponse("Error: %s" % str(e), status_code=400)
     finally:
         #commits changes to db
@@ -125,7 +159,7 @@ def delete(param1, param2):
         #properly closes the connection
         cursor.close()
         cnxn.close()
-        logging.info('Closed the db connection')   
+        logging.debug('Closed the db connection')   
 
 ### POST API method function not implemented for this endpoint, use userId/tasks instead ### 
 
@@ -138,18 +172,19 @@ def connect():
         db_username = os.environ["ENV_DATABASE_USERNAME"]
         db_password = os.environ["ENV_DATABASE_PASSWORD"]
         driver = '{ODBC Driver 17 for SQL Server}'
-        logging.info('Uses hardcoded ODBC Driver 17 for SQL Server string')
+        logging.debug('Uses hardcoded ODBC Driver 17 for SQL Server string')
         #assigns the connection string
         conn_string = "Driver={};Server={};Database={};Uid={};Pwd={};Encrypt=yes;TrustServerCertificate=no;Connection Timeout=30;".format(
         driver, db_server, db_name, db_username, db_password)
      
         #creates and returns connection variable
-        logging.debug('Attempting DB connection')
-        try:
+        try:         
+            logging.debug('Attempting DB connection')
             cnxn = pyodbc.connect(conn_string)
+        except (pyodbc.InterfaceError) as e:
+            logging.critical('Failed to connect to DB: ' + e.args[0])
         except (pyodbc.DatabaseError, pyodbc.InterfaceError) as e:
-            logging.error('Failed to connect to DB: ' + e.args[0])
-            logging.error("Error: " + e.args[1])
+            logging.debug('Failed to connect to DB: ' + e.args[1])
             return func.HttpResponse(status_code=500)
         logging.debug("Connection to DB successful!")
         return cnxn
@@ -164,13 +199,12 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
 #collects parameters passed in url        
     userId = req.route_params.get('userId')
     taskId = req.route_params.get('taskId')
-    logging.info('Trying to get userId and taskId')
+    logging.debug('Trying to get userId and taskId')
     req_body = {}
     try:
         req_body = req.get_json()
     except ValueError:
         pass
-
     if (not userId) and (not taskId):
         logging.debug("Got neither userId nor taskId")
         userId = req_body.get('userId')
@@ -180,9 +214,6 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
 
 #determines which API method was requested, and calls the API method
     method = req.method
-    if not method:
-        logging.critical('No method available')
-        raise Exception('No method passed')
 
     try:
     #if GET method is selected, it executes here
@@ -191,14 +222,21 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
             return (get(userId, taskId))
 
     #if PUT method is selected, it executes here
-        if method == "PUT":
+        elif method == "PUT":
             logging.debug('Passed PUT method')   
             return (update(userId, taskId, req_body))
 
-    #if DELETE method is selected, it executes here
-        if method == "DELETE":
+    #if PATCH method is selected, it executes here
+        elif method == "PATCH":
+            logging.debug('Passed PATCH method')   
+            return 
+
+        elif method == "DELETE":
             logging.debug('Passed DELETE method')   
             return (delete(userId, taskId))
+        else:
+            logging.warn(f"Request with method {method} is not allowed for this endpoint")
+            func.HttpResponse(status_code=405)
 
     #displays erros, if any, encountered when API methods were called
     except Exception as e:

--- a/functions/HttpTriggerAPIUsersIdTaskId/function.json
+++ b/functions/HttpTriggerAPIUsersIdTaskId/function.json
@@ -8,10 +8,10 @@
       "name": "req",
       "methods": [
         "get",
-        "post",
         "delete",
         "update"
-      ]
+      ],
+      "route": "users/{userId:int?}/task/{taskId:int?}"
     },
     {
       "type": "http",

--- a/functions/HttpTriggerAPIUsersIdTaskId/function.json
+++ b/functions/HttpTriggerAPIUsersIdTaskId/function.json
@@ -9,6 +9,7 @@
       "methods": [
         "get",
         "put",
+        "patch",
         "delete"
       ],
       "route": "users/{userId:int?}/task/{taskId:int?}"

--- a/functions/HttpTriggerAPIUsersIdTaskId/function.json
+++ b/functions/HttpTriggerAPIUsersIdTaskId/function.json
@@ -8,8 +8,8 @@
       "name": "req",
       "methods": [
         "get",
-        "delete",
-        "update"
+        "put",
+        "delete"
       ],
       "route": "users/{userId:int?}/task/{taskId:int?}"
     },

--- a/functions/HttpTriggerAPIUsersIdTaskId/function.json
+++ b/functions/HttpTriggerAPIUsersIdTaskId/function.json
@@ -12,7 +12,7 @@
         "patch",
         "delete"
       ],
-      "route": "users/{userId:int?}/task/{taskId:int?}"
+      "route": "users/{userId:int?}/tasks/{taskId:int?}"
     },
     {
       "type": "http",


### PR DESCRIPTION
### Resolves #83 

This code completes the implementation of the Azure function for the `/users/user_id/tasks/task_id endpoint`
The function will be deployed to the cloud following the approval and merge into the development branch
It doesn't require configuration to be run on the cloud
### To test locally:
Make sure you have the Azure functions extension for VSCode
Pull the latest iteration of this branch
Install the ODBC driver necessary to connect to the database (pyodbc or pypyodbc)
Configure your venv and vscode files to set up the appropriate runtime for this Azure function
In local.settings.json at the root of the functions folder, enter in the values for the keys below in the following format: { "Values": { "KEY": "VALUE" } }
ENV_DATABASE_NAME (name of the database)
ENV_DATABASE_PASSWORD
ENV_DATABASE_SERVER (this is the server location)
ENV_DATABASE_USERNAME

In VSCode, click `F5 `or `run->Start Debugging `in the functions folder to fire up the function
After the function has started, input the url provided in terminal window into Postman, and test the functionality by selecting the appropriate method and url parameters and/or json body, like so:

**GET method**
Pass the userId and taskId as url parameters, JSON body is not required
<img width="1009" alt="Screen Shot 2021-01-31 at 5 20 07 PM" src="https://user-images.githubusercontent.com/46657216/106405856-5be38080-63ec-11eb-98be-8da841847a09.png">


**PUT method**:
Pass the userId and taskId as url parameters, JSON body IS required to include `title`, `description`, `dueDate`, `completed`, `completedDate` (all five updatable fields need to be present, all other JSON fields will be ignored), you may pass more by cutting and pasting from GET results
You may use this sample JSON for update testing:
```
{
    "userId": 16,
    "taskId": 24,
    "title": "My Question",
    "description": "Decide on if to be or not to be",
    "dueDate": null,
    "completed": 1,
    "completedDate":"21/01/07 05:46:38"
}
```
Note that the in-built `datetime `conversion will only work for legitimate `yy/mm/dd hh:mm:ss` If you attempt to update the due date to occur on 20/13/32, you will receive an error.
**Be sure to add the data in the `"yy/mm/dd hh:mm:ss"` string format**, otherwise you will receive an error.

successful request results:
<img width="998" alt="Screen Shot 2021-01-31 at 5 20 47 PM" src="https://user-images.githubusercontent.com/46657216/106406035-e62be480-63ec-11eb-9f94-33da60aa76da.png">
**PATCH method**
Same instructions as for PUT, userId and taskId are required, JSON body may contain one to five key-value pairs excluding userId and taskId. If "Completed" is included, it may not be null per db specifications.
<img width="991" alt="Screen Shot 2021-01-31 at 5 35 52 PM" src="https://user-images.githubusercontent.com/46657216/106406150-4458c780-63ed-11eb-9fa5-52f75828842b.png">

PUT and PATCH results: 
<img width="992" alt="Screen Shot 2021-01-31 at 5 36 19 PM" src="https://user-images.githubusercontent.com/46657216/106406186-5fc3d280-63ed-11eb-9bc7-ec6b43a785de.png">


**DELETE method**
Pass the userId and taskId as url parameters, JSON body is not required.
_Please DO NOT delete the record with userId = 16, taskId = 24
taskId = 25-26 for userId =16 are available for the delete functionality testing.
If the requested taskId is not in the db, you will receive an error message:
<img width="1000" alt="Screen Shot 2021-01-28 at 2 44 17 PM" src="https://user-images.githubusercontent.com/46657216/106208145-c6d85180-6177-11eb-85fe-a51e2bbcb2aa.png">
