### PR TITLE
adds automation for creating Redis-cache

### DIFF
--- a/Automation/Redis_Cache/deploy.ps1
+++ b/Automation/Redis_Cache/deploy.ps1
@@ -1,0 +1,27 @@
+
+# to run this, navigate to the Powershell  /Automation/Redis_Cache/deploy.ps1
+
+
+param(
+        [string] [Parameter(Mandatory=$true)] $SubscriptionId,
+        [string] [Parameter(Mandatory=$true)] $ResourceGroupName,
+        [string] [Parameter(Mandatory=$true)] $Location,
+        [string] [Parameter(Mandatory=$true)] $Redis_nsc_redis_dev_usw2_thursday_name
+
+      )
+
+$pathToRedisTemplate = "/Users/student/Documents/GitHub/ad440-winter2021-thursday-repo/Automation/Redis_Cache/template.json"   
+
+
+
+# Creates REDIS CACHE if one of the same name does not already exist in the Resource Group
+$RedisExists = (Get-AzRedisCache -ResourceGroupName “nsc-rg-dev-usw2-thursday” -Name “nsc-redis-dev-usw2-thursday”) 
+      
+if (!$RedisExists) { 
+    Write-Host "Redis Cache does not exist. Creating now."
+    # create redis with given name (can also add address prefix and location if not same as rg)
+    New-AzResourceGroupDeployment -ResourceGroupName $ResourceGroupName -TemplateFile $pathToRedisTemplate 
+} else {
+    Write-Host "Redis Cache with name nsc-redis-dev-usw2-thursday already exists."
+}
+

--- a/Automation/Redis_Cache/deploy.ps1
+++ b/Automation/Redis_Cache/deploy.ps1
@@ -3,10 +3,8 @@
 
 
 param(
-        [string] [Parameter(Mandatory=$true)] $SubscriptionId,
         [string] [Parameter(Mandatory=$true)] $ResourceGroupName,
-        [string] [Parameter(Mandatory=$true)] $Location,
-        [string] [Parameter(Mandatory=$true)] $Redis_nsc_redis_dev_usw2_thursday_name
+        [string] [Parameter(Mandatory=$true)] $RedisServerName
 
       )
 
@@ -15,7 +13,7 @@ $pathToRedisTemplate = "Automation/Redis_Cache/template.json"
 
 
 # Creates REDIS CACHE if one of the same name does not already exist in the Resource Group
-$RedisExists = (Get-AzRedisCache -ResourceGroupName “nsc-rg-dev-usw2-thursday” -Name “nsc-redis-dev-usw2-thursday”) 
+$RedisExists = (Get-AzRedisCache -ResourceGroupName $ResourceGroupName -Name $RedisServerName) 
       
 if (!$RedisExists) { 
     Write-Host "Redis Cache does not exist. Creating now."
@@ -25,3 +23,5 @@ if (!$RedisExists) {
     Write-Host "Redis Cache with name nsc-redis-dev-usw2-thursday already exists."
 }
 
+# -ResourceGroupName “nsc-rg-dev-usw2-thursday”
+# -RedisServerName “nsc-redis-dev-usw2-thursday”

--- a/Automation/Redis_Cache/deploy.ps1
+++ b/Automation/Redis_Cache/deploy.ps1
@@ -10,7 +10,7 @@ param(
 
       )
 
-$pathToRedisTemplate = "/Users/student/Documents/GitHub/ad440-winter2021-thursday-repo/Automation/Redis_Cache/template.json"   
+$pathToRedisTemplate = "Automation/Redis_Cache/template.json"   
 
 
 

--- a/Automation/Redis_Cache/deploy.ps1
+++ b/Automation/Redis_Cache/deploy.ps1
@@ -8,7 +8,7 @@ param(
 
       )
 
-$pathToRedisTemplate = "Automation/Redis_Cache/template.json"   
+$pathToRedisTemplate = "./template.json"   
 
 
 

--- a/Automation/Redis_Cache/deploy.ps1
+++ b/Automation/Redis_Cache/deploy.ps1
@@ -20,7 +20,7 @@ if (!$RedisExists) {
     # create redis with given name (can also add address prefix and location if not same as rg)
     New-AzResourceGroupDeployment -ResourceGroupName $ResourceGroupName -TemplateFile $pathToRedisTemplate 
 } else {
-    Write-Host "Redis Cache with name nsc-redis-dev-usw2-thursday already exists."
+    Write-Host "Redis Cache with name " $RedisServerName "already exists."
 }
 
 # -ResourceGroupName “nsc-rg-dev-usw2-thursday”

--- a/Automation/Redis_Cache/template.json
+++ b/Automation/Redis_Cache/template.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "Redis_nsc_redis_dev_usw2_thursday_name": {
+            "defaultValue": "nsc-redis-dev-usw2-thursday2",
+            "type": "String"
+        }
+    },
+    "variables": {},
+    "resources": [
+        {
+            "type": "Microsoft.Cache/Redis",
+            "apiVersion": "2019-07-01",
+            "name": "[parameters('Redis_nsc_redis_dev_usw2_thursday_name')]",
+            "location": "West US 2",
+            "properties": {
+                "sku": {
+                    "name": "Standard",
+                    "family": "C",
+                    "capacity": 1
+                },
+                "enableNonSslPort": false,
+                "minimumTlsVersion": "1.2",
+                "redisConfiguration": {
+                    "maxclients": "1000",
+                    "maxmemory-reserved": "50",
+                    "maxfragmentationmemory-reserved": "50",
+                    "maxmemory-delta": "50"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Closes #155 - Team 3

This feature creates an adds an automation script that first, checks if the Redis Cache "nsc-redis-dev-usw2-thursday2" is already created and if not proceeds by  creating one though a New-AzResourceGroupDeployment with the specified Resource Group


## Testing


- Navigate to the Repo's   /Automation/Redis_Cache/deploy.ps1 folder and copy the path into Powershell 
- With this sample run, the script first checks if our Redis Cache is created , since it has already been created the script stops there.

<img width="901" alt="Screen Shot 2021-02-20 at 6 48 05 PM" src="https://user-images.githubusercontent.com/57120136/108614062-3a9f0000-73ac-11eb-953b-bc68bc9367ab.png">


- If this Redis Cache was not already created, the correct inputed parameters will create a new Redis Cache with the  New-AzResourceGroupDeployment command.
- You will then see PowerShell Prompt the user with this.

<img width="289" alt="Screen Shot 2021-02-17 at 9 34 57 PM" src="https://user-images.githubusercontent.com/57120136/108310349-16eb7800-7168-11eb-8015-d0260cd40ce6.png">





**Troubleshooting Tips**

It is possible to run this through Visual Studio code, But the PowerShell extension should be installed first, Otherwise. If you run the command  through PowerShell and the Redis-Cache is not created yet, and does not implement itself into creation it is recommended that the correct subscription-ID and Resource Group is being used through Azure. Documentation on the resources: `https://docs.microsoft.com/en-us/powershell/module/az.rediscache/?view=azps-5.5.0`

Date | Activity | Time Spent
-- | -- | --
2/04/2021|Research how to Create a Redis Cache in Azure |3 hours
2/06/2021|Create the correct Redis Cache under desired Resource Group |2 hours
2/08/2021|Research how to Create a Redis Cache in Azure with automation | 4 hours 
2/16/2021|Implement script to check if Redis Cache is created | 3 hours
2/17/2021|Implement script to create Redis Cache if not created | 3 hours