### PR TITLE
Redis Cache users/userID/tasks and Perf Test Fixes

### DIFF
--- a/.github/workflows/performancetest-users-userID.yaml
+++ b/.github/workflows/performancetest-users-userID.yaml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_PREFIX: "~/.npm-global"
-      STAGE_NAME: merge-perf-test
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -34,7 +33,8 @@ jobs:
       # - currently this just runs the defaults
       # examples for future:
       # - run: cp ./slsart/script.yml ./
-      # - run: cp ./slsart/serverless.yml ./
+  
+          
       - name: Deploy, invoke, remove functions
         run: |
           ~/.npm-global/bin/slsart deploy --region $AWS_SLSART_REGION

--- a/functions/HttpTriggerAPIUsersIdTask/__init__.py
+++ b/functions/HttpTriggerAPIUsersIdTask/__init__.py
@@ -46,7 +46,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
         rDB.ping()
         logging.debug("Connected to Redis!")
     except(redis.exceptions.ConnectionError, ConnectionRefusedError) as e:
-            logging.error("Redis connection error!" + e.arge[0])
+            logging.error("Redis connection error!" + e.args[0])
             
 
     try:

--- a/test/artillery/performanceScript-users-userID.yaml
+++ b/test/artillery/performanceScript-users-userID.yaml
@@ -6,8 +6,7 @@
 config:
   # this hostname will be used as a prefix for each URI in the flow unless a complete URI is specified
   target: "http://nsc.functionsapp-team1.azurewebsites.net/api/"
-  phases:
-    
+  phases: 
      - duration: 50 #warmup
        arrivalRate: 5
        variables:
@@ -17,23 +16,13 @@ config:
               - "3"
               - "5"
               - "6"
-      
-    - duration: 200 #stress test
-      arrivalRate: 1
-      rampTo: 50
-      variables:
-         - user:
-              - "1"
-              - "2"
-              - "3"
-              - "5"
-              - "6"
+    
          
 scenarios:
-  -
-    flow:
+     - flow:
+        - get:
+             url: "/users/{{user}}"
 
-      - get:
-          url: "/users/{{user}}"
+     
 
      


### PR DESCRIPTION
-Added Redis cache for users/userID/tasks that expires after 20 seconds, and reroutes subsequent requests within those 20 seconds to the Cache 

-Redis cache is initialized along with SQL sever, and attempts to connect with try/catch implementation and logging.
-When a get request is made, all tasks are loaded into a JSON object, and then loaded into the redis server as users:user_id:tasks:all, immediately after which, an expire tag is added to the cache, to expire users:user_id:tasks:all after 20 seconds. If another get request is made within those 20 seconds, the request will get from the redis cache instead of the SQL server, reducing lag. 

-Fixes for Performance Script