### PR TITLE
Fix Deployment of Functions

### DIFF
--- a/.github/workflows/deploy-apis.yaml
+++ b/.github/workflows/deploy-apis.yaml
@@ -36,7 +36,7 @@ jobs:
         app-name: ${{ secrets.AZURE_FUNCTIONAPP_NAME }} # this is the name of the function established in the env portion
         package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }} # this is the path established in the env portion
         publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }} # this is the secret we've created on GitHub that contains the details necessary to push to Azure
-
+        scm-do-build-during-deployment: 'True'
         # This file was used as reference for deployment of the function app
         # (getting values for app-name and publish-profile for the function app)
         # Feb-10-2021

--- a/functions/HttpTriggerAPIUsersId/__init__.py
+++ b/functions/HttpTriggerAPIUsersId/__init__.py
@@ -14,7 +14,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
 
     #Initiating REDIS cache
     REDIS_HOST = 'nsc-redis-dev-usw2-thursday.redis.cache.windows.net'
-    r = redis.Redis(host= REDIS_HOST, port= 6380, db= 0, password= '${{ secrets.ENV_REDIS_KEY }}', ssl= True)
+    r = redis.Redis(host= REDIS_HOST, port= 6380, db= 0, password= os.environ["ENV_REDIS_KEY"], ssl= True)
 
     #Something to test the redis cache
     r.get("2")

--- a/functions/HttpTriggerAPIUsersIdTask/__init__.py
+++ b/functions/HttpTriggerAPIUsersIdTask/__init__.py
@@ -42,7 +42,7 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     #Redis Sever
     try:
         
-        rDB = redis.Redis(host='nsc-redis-dev-usw2-thursday.redis.cache.windows.net', port='6380', db=0, password='${{ secrets.ENV_REDIS_KEY }}', ssl=True) 
+        rDB = redis.Redis(host='nsc-redis-dev-usw2-thursday.redis.cache.windows.net', port='6380', db=0, password= os.environ["ENV_REDIS_KEY"], ssl=True) 
         rDB.ping()
         logging.debug("Connected to Redis!")
     except(redis.exceptions.ConnectionError, ConnectionRefusedError) as e:


### PR DESCRIPTION
Closes #205 

Added build on deploy to the options of the github action that deploys the functions and updated the redis key for 2 of the API functions. This will help with a couple of the errors we are getting with functions. Also added the redis key to the functions app on Azure so that os.environ["ENV_REDIS_KEY"] will work.

There were also issues with the get method in the UsersId api function which is causing errors as well. I created a ticket for it, #212 

### Testing
This will be difficult but can be done by updating a function and merging it, maybe a comment. You'll see the updated function in the Functions App with the comment.

When using the UsersId function to get a user, you should now see this error instead of a password/redis error:
![Screen Shot 2021-02-26 at 7 37 21 PM](https://user-images.githubusercontent.com/22699679/109374427-1343a980-786a-11eb-9b42-29c8b348bcf4.png)

|**DATE**|**ACTIVITY**|**TIME**|
|---|:---|:---|
|2/25|Azure Deploy error research|3 hours|
|2/25|Testing|1 hour|
|2/25|Code Review/bug hunt|2.5 hours|
|2/26|Research and final testing|1.5 hours|
|2/26|PR/Task updating|0.5 hours|

