### PR TITLE
SQL injection DELETE test for /users/{user_id} 

### DIFF
--- a/.github/workflows/sql-injection-delete-users-userid.yml
+++ b/.github/workflows/sql-injection-delete-users-userid.yml
@@ -1,0 +1,33 @@
+name: SQL injection test for DELETE users/userid
+
+on:
+  push:
+    branches:
+      - development
+env:
+  NODE_VERSION: '10.x'
+  RESULT_FILE_PATH: ../../test/security/sql-injection/delete-users-userid.json
+
+jobs:
+  DELETE-test-case:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      # Test set up
+      - name: 'Create test user for delete injection test'
+        run: |
+          curl -v -X POST -d '{"firstName": "inject-del-fname", "lastName": "inject-del-lname", "email": "inject-del-email"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users > test/security/sql-injection/delete-users-userid.json
+      - name: 'Get userId'
+        id: userId
+        uses: notiz-dev/github-action-json-property@release
+        with: 
+          path: env.RESULT_FILE_PATH
+          prop_path: 'userId'
+
+
+
+      # Remove test file created
+      - name: 'Remove Test Results File'
+        uses: JesseTG/rm@v1.0.2
+        with:
+          path: env.RESULT_FILE_PATH

--- a/.github/workflows/sql-injection-delete-users-userid.yml
+++ b/.github/workflows/sql-injection-delete-users-userid.yml
@@ -54,11 +54,22 @@ jobs:
         with: 
           path: test/security/sql-injection/delete-users-userid.json
           prop_path: 'email'
-      
+
+      # TO DO: Once email is accurately returned by a get request this test should be used instead to cause an error when emails don't match
+      # - name: "Compare current email to original"
+      #   run: echo ${{ steps.getEmail.outputs.prop == 'inject-update-email' }} ${{'Injection unsuccessful; email remains unaltered.'}}
+
+      # TO DO: Delete later
       # Check for userUpdateId email changes in results file
       - name: "Compare current email to original"
         if: ${{ steps.getEmail.outputs.prop ==  'inject-update-email' }}
         run: echo "Injection unsuccessful; email remains unaltered:"" ${{ steps.getEmail.outputs.prop }} = ${{ 'inject-update-email' }}"
+
+      # TO DO: Delete later
+      # Emails don't match; display them with an error message for now
+      - name: "ERROR - Compare current email to original"
+        if: ${{ steps.getEmail.outputs.prop != 'inject-update-email' }}
+        run: echo "ERROR - Injection successful; email isn't the same:"" ${{ steps.getEmail.outputs.prop }} = ${{ 'inject-update-email' }}"
       
       # Remove test results file
       - name: 'Remove Test Results File'

--- a/.github/workflows/sql-injection-delete-users-userid.yml
+++ b/.github/workflows/sql-injection-delete-users-userid.yml
@@ -1,8 +1,10 @@
 name: SQL injection test for DELETE users/userid
+
 on:
   push:
     branches:
       - development
+      
 env:
   NODE_VERSION: '10.x'
   RESULT_FILE_PATH: ../../test/security/sql-injection/delete-users-userid.json
@@ -16,6 +18,7 @@ jobs:
       - name: 'Create test user to delete'
         run: |
           curl -v -X POST -d '{"firstName": "inject-del-fname", "lastName": "inject-del-lname", "email": "inject-del-email"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users > test/security/sql-injection/delete-users-userid.json
+
       # Retrieve userId from json result file
       - name: 'Get userId-to delete'
         id: userDeleteId
@@ -24,27 +27,30 @@ jobs:
           path: env.RESULT_FILE_PATH
           prop_path: 'userId'
 
-      # Create test user and write user json to result file
+      # Create test user to update and write user json to result file
       - name: 'Create test user to update'
         run: |
           curl -v -X POST -d '{"firstName": "inject-update-fname", "lastName": "inject-update-lname", "email": "inject-update-email"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users > test/security/sql-injection/delete-users-userid.json
+
       # Retrieve userId from json result file
       - name: 'Get userId-to update'
         id: userUpdateId
         uses: notiz-dev/github-action-json-property@release
         with: 
           path: env.RESULT_FILE_PATH
-          prop_path: 'userId'
+          prop_path: 'userId'  
 
-
-  
-
-      # Attempt delete injection on userUpdateId and update json result file
+      # Attempt update injection on email and update result file
       - name: "Delete user with userId ${{steps.userDeleteId.outputs.prop}}"
         run: |
-          curl -v -X DELETE -d '{"userId": "'${{steps.userDeleteId.outputs.prop}}'); or 1=1; UPDATE users SET email='attacked email' WHERE userId='${{steps.userUpdateId.outputs.prop}}'; --"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{steps.userDeleteId.outputs.prop}} > test/security/sql-injection/delete-users-userid.json
+          curl -v -X DELETE -d '{"userId": "'${{steps.userDeleteId.outputs.prop}}'); or 1=1; UPDATE users SET email='attacked email' WHERE userId = ${{steps.userUpdateId.outputs.prop}}; --"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{steps.userDeleteId.outputs.prop}} > test/security/sql-injection/delete-users-userid.json
 
       # Check for userDeleteId in json result file
+      - name: 'Check for userDeleteId deletion'
+        run: |
+          curl -v -X GET https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{steps.userDeleteId.outputs.prop}} > test/security/sql-injection/delete-users-userid.json
+
+      # Retrieve GET results
       - name: 'Check for userDeleteId deletion'
         id: deletionCheck
         uses: notiz-dev/github-action-json-property@release
@@ -52,20 +58,26 @@ jobs:
           path: env.RESULT_FILE_PATH
           prop_path: 'userId'
 
+      # Check for userDeleteId in json result file
       - name: "User deletion confirmation"
-        run: "Deleted user " ${{steps.deletionCheck.outputs.prop}}
+        if: ${{steps.deletionCheck.outputs.prop}} != ${{steps.userDeleteId.outputs.prop}}
+        run: echo "Deleted user " ${{steps.deletionCheck.outputs.prop}}
 
       # Check for userUpdateId email update in json result file
-      - name: 'Check for userUpdateteId email attack'
-        id: injectionCheck
+      - name: 'Get userUpdateteId email'
+        run: |
+          curl -v -X GET https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{steps.userUpdateId.outputs.prop}} > test/security/sql-injection/delete-users-userid.json
+      - name: 'Retrieve email from GET request'
+        id: getEmail
         uses: notiz-dev/github-action-json-property@release
         with: 
           path: env.RESULT_FILE_PATH
           prop_path: 'email'
 
-      - name: "Email update injection confirmation"
-        run: "Email updated " ${{steps.injectionCheck.outputs.prop}}
-
+      # Use the output from above step
+      - name: "Compare email to original"
+        if: ${{steps.getEmail.outputs.prop}} = "inject-update-email"}}
+        run: echo "Injection unsuccessful; email remains unaltered:"" ${{steps.getEmail.outputs.prop}} = "inject-update-email"}}" 
 
       # Remove test results file
       - name: 'Remove Test Results File'

--- a/.github/workflows/sql-injection-delete-users-userid.yml
+++ b/.github/workflows/sql-injection-delete-users-userid.yml
@@ -5,6 +5,7 @@ on:
       - development
 env:
   NODE_VERSION: '10.x'
+
 jobs:
   DELETE-user-test-case:
     runs-on: ubuntu-latest
@@ -13,58 +14,52 @@ jobs:
       # Create test user to delete and write user json to result file
       - name: 'Create test user to delete'
         run: |
-          curl -v -X POST -d '{"firstName": "inject-del-fname", "lastName": "inject-del-lname", "email": "inject-del-email"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users > test/security/sql-injection/delete-users-userid.json
-      # Retrieve userId from json result file
-      - name: 'Get userId-to delete'
+          curl -v POST -d '{ "firstName": "inject-del-fname", "lastName": "inject-del-lname", "email": "inject-del-email" }' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users > test/security/sql-injection/delete-users-userid.json
+      
+      # Retrieve userId from result file
+      - name: 'Retrieve userId-to delete'
         id: userDeleteId
         uses: notiz-dev/github-action-json-property@release
         with: 
           path: test/security/sql-injection/delete-users-userid.json
           prop_path: 'userId'
+      
       # Create test user to update and write user json to result file
-      - name: 'Create test user to update'
+      - name: 'Create userId-to update'
         run: |
-          curl -v -X POST -d '{"firstName": "inject-update-fname", "lastName": "inject-update-lname", "email": "inject-update-email"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users > test/security/sql-injection/delete-users-userid.json
-      # Retrieve userId from json result file
-      - name: 'Get userId-to update'
+          curl -v POST -d '{ "firstName": "inject-update-fname", "lastName": "inject-update-lname", "email": "inject-update-email" }' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users > test/security/sql-injection/delete-users-userid.json
+      
+      # Retrieve userId from result file
+      - name: 'Retrieve userId-to update'
         id: userUpdateId
         uses: notiz-dev/github-action-json-property@release
         with: 
           path: test/security/sql-injection/delete-users-userid.json
           prop_path: 'userId'  
-      # Attempt update injection on email and update result file
-      - name: "Delete user with userId ${{steps.userDeleteId.outputs.prop}}"
+      
+      # Attempt update injection on email and update results file
+      - name: "Delete user with userId ${{ steps.userDeleteId.outputs.prop }}"
         run: |
-          curl -v -X DELETE -d '{"userId": "'${{steps.userDeleteId.outputs.prop}}'); or 1=1; UPDATE users SET email='attacked email' WHERE userId = ${{steps.userUpdateId.outputs.prop}}; --"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{steps.userDeleteId.outputs.prop}} > test/security/sql-injection/delete-users-userid.json
-      # Check for userDeleteId in json result file
-      - name: 'Make GET request for userDeleteId after delete attempt'
-        run: |
-          curl -v -X GET https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{steps.userDeleteId.outputs.prop}} > test/security/sql-injection/delete-users-userid.json
-      # Retrieve GET results
-      - name: 'Check for userDeleteId deletion'
-        id: deletionCheck
-        uses: notiz-dev/github-action-json-property@release
-        with: 
-          path: test/security/sql-injection/delete-users-userid.json
-          prop_path: 'userId'
-      # Check for userDeleteId in json result file
-      - name: "User deletion confirmation"
-        if: ${{steps.deletionCheck.outputs.prop}} != ${{steps.userDeleteId.outputs.prop}}
-        run: echo "Deleted user " ${{steps.deletionCheck.outputs.prop}}
-      # Check for userUpdateId email update in json result file
+          curl -v -X DELETE -d '{ "userId": "'${{ steps.userDeleteId.outputs.prop }}'); or 1=1; UPDATE users SET email='attacked email' WHERE userId = ${{ steps.userUpdateId.outputs.prop }}; --" }' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{ steps.userDeleteId.outputs.prop }} > test/security/sql-injection/delete-users-userid.json
+      
+      # GET userUpdateId email into results file
       - name: 'Get userUpdateteId email'
         run: |
-          curl -v -X GET https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{steps.userUpdateId.outputs.prop}} > test/security/sql-injection/delete-users-userid.json
-      - name: 'Retrieve email from GET request'
+          curl -v GET https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{ steps.userUpdateId.outputs.prop }} > test/security/sql-injection/delete-users-userid.json
+      
+      # Retrieve email from results file
+      - name: 'Retrieve current email from GET request'
         id: getEmail
         uses: notiz-dev/github-action-json-property@release
         with: 
           path: test/security/sql-injection/delete-users-userid.json
           prop_path: 'email'
-      # Use the output from above step
-      - name: "Compare email to original"
-        if: ${{steps.getEmail.outputs.prop}} = "inject-update-email"}}
-        run: echo "Injection unsuccessful; email remains unaltered:"" ${{steps.getEmail.outputs.prop}} = "inject-update-email"}}" 
+      
+      # Check for userUpdateId email changes in results file
+      - name: "Compare current email to original"
+        if: ${{ steps.getEmail.outputs.prop }} == {{ 'inject-update-email' }}
+        run: echo "Injection unsuccessful; email remains unaltered:"" ${{ steps.getEmail.outputs.prop }} = ${{ 'inject-update-email' }}" 
+      
       # Remove test results file
       - name: 'Remove Test Results File'
         uses: JesseTG/rm@v1.0.2

--- a/.github/workflows/sql-injection-delete-users-userid.yml
+++ b/.github/workflows/sql-injection-delete-users-userid.yml
@@ -40,7 +40,7 @@ jobs:
       # Attempt update injection on email and update results file
       - name: "Delete user with userId ${{ steps.userDeleteId.outputs.prop }}"
         run: |
-          curl -v -X DELETE -d '{ "userId": "'${{ steps.userDeleteId.outputs.prop }}'); or 1=1; UPDATE users SET email='attacked email' WHERE userId = ${{ steps.userUpdateId.outputs.prop }}; --" }' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{ steps.userDeleteId.outputs.prop }} > test/security/sql-injection/delete-users-userid.json
+          curl -v -X DELETE -d "{ \"userId\": \"'${{ steps.userDeleteId.outputs.prop }}'); UPDATE users SET email='attacked email' WHERE userId = ${{ steps.userUpdateId.outputs.prop }}; --\" }" https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{ steps.userDeleteId.outputs.prop }} > test/security/sql-injection/delete-users-userid.json
       
       # GET userUpdateId email into results file
       - name: 'Get userUpdateteId email'
@@ -57,8 +57,8 @@ jobs:
       
       # Check for userUpdateId email changes in results file
       - name: "Compare current email to original"
-        if: ${{ steps.getEmail.outputs.prop }} == {{ 'inject-update-email' }}
-        run: echo "Injection unsuccessful; email remains unaltered:"" ${{ steps.getEmail.outputs.prop }} = ${{ 'inject-update-email' }}" 
+        if: ${{ steps.getEmail.outputs.prop ==  'inject-update-email' }}
+        run: echo "Injection unsuccessful; email remains unaltered:"" ${{ steps.getEmail.outputs.prop }} = ${{ 'inject-update-email' }}"
       
       # Remove test results file
       - name: 'Remove Test Results File'

--- a/.github/workflows/sql-injection-delete-users-userid.yml
+++ b/.github/workflows/sql-injection-delete-users-userid.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           curl -v -X DELETE -d '{"userId": "'${{steps.userDeleteId.outputs.prop}}'); or 1=1; UPDATE users SET email='attacked email' WHERE userId = ${{steps.userUpdateId.outputs.prop}}; --"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{steps.userDeleteId.outputs.prop}} > test/security/sql-injection/delete-users-userid.json
       # Check for userDeleteId in json result file
-      - name: 'Check for userDeleteId deletion'
+      - name: 'Make GET request for userDeleteId after delete attempt'
         run: |
           curl -v -X GET https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{steps.userDeleteId.outputs.prop}} > test/security/sql-injection/delete-users-userid.json
       # Retrieve GET results

--- a/.github/workflows/sql-injection-delete-users-userid.yml
+++ b/.github/workflows/sql-injection-delete-users-userid.yml
@@ -1,14 +1,11 @@
 name: SQL injection test for DELETE users/userid
-
 on:
   push:
     branches:
       - development
-      
 env:
   NODE_VERSION: '10.x'
   RESULT_FILE_PATH: ../../test/security/sql-injection/delete-users-userid.json
-
 jobs:
   DELETE-user-test-case:
     runs-on: ubuntu-latest
@@ -18,7 +15,6 @@ jobs:
       - name: 'Create test user to delete'
         run: |
           curl -v -X POST -d '{"firstName": "inject-del-fname", "lastName": "inject-del-lname", "email": "inject-del-email"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users > test/security/sql-injection/delete-users-userid.json
-
       # Retrieve userId from json result file
       - name: 'Get userId-to delete'
         id: userDeleteId
@@ -26,12 +22,10 @@ jobs:
         with: 
           path: env.RESULT_FILE_PATH
           prop_path: 'userId'
-
       # Create test user to update and write user json to result file
       - name: 'Create test user to update'
         run: |
           curl -v -X POST -d '{"firstName": "inject-update-fname", "lastName": "inject-update-lname", "email": "inject-update-email"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users > test/security/sql-injection/delete-users-userid.json
-
       # Retrieve userId from json result file
       - name: 'Get userId-to update'
         id: userUpdateId
@@ -39,17 +33,14 @@ jobs:
         with: 
           path: env.RESULT_FILE_PATH
           prop_path: 'userId'  
-
       # Attempt update injection on email and update result file
       - name: "Delete user with userId ${{steps.userDeleteId.outputs.prop}}"
         run: |
           curl -v -X DELETE -d '{"userId": "'${{steps.userDeleteId.outputs.prop}}'); or 1=1; UPDATE users SET email='attacked email' WHERE userId = ${{steps.userUpdateId.outputs.prop}}; --"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{steps.userDeleteId.outputs.prop}} > test/security/sql-injection/delete-users-userid.json
-
       # Check for userDeleteId in json result file
       - name: 'Check for userDeleteId deletion'
         run: |
           curl -v -X GET https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{steps.userDeleteId.outputs.prop}} > test/security/sql-injection/delete-users-userid.json
-
       # Retrieve GET results
       - name: 'Check for userDeleteId deletion'
         id: deletionCheck
@@ -57,12 +48,10 @@ jobs:
         with: 
           path: env.RESULT_FILE_PATH
           prop_path: 'userId'
-
       # Check for userDeleteId in json result file
       - name: "User deletion confirmation"
         if: ${{steps.deletionCheck.outputs.prop}} != ${{steps.userDeleteId.outputs.prop}}
         run: echo "Deleted user " ${{steps.deletionCheck.outputs.prop}}
-
       # Check for userUpdateId email update in json result file
       - name: 'Get userUpdateteId email'
         run: |
@@ -73,12 +62,10 @@ jobs:
         with: 
           path: env.RESULT_FILE_PATH
           prop_path: 'email'
-
       # Use the output from above step
       - name: "Compare email to original"
         if: ${{steps.getEmail.outputs.prop}} = "inject-update-email"}}
         run: echo "Injection unsuccessful; email remains unaltered:"" ${{steps.getEmail.outputs.prop}} = "inject-update-email"}}" 
-
       # Remove test results file
       - name: 'Remove Test Results File'
         uses: JesseTG/rm@v1.0.2

--- a/.github/workflows/sql-injection-delete-users-userid.yml
+++ b/.github/workflows/sql-injection-delete-users-userid.yml
@@ -55,21 +55,9 @@ jobs:
           path: test/security/sql-injection/delete-users-userid.json
           prop_path: 'email'
 
-      # TO DO: Once email is accurately returned by a get request this test should be used instead to cause an error when emails don't match
-      # - name: "Compare current email to original"
-      #   run: echo ${{ steps.getEmail.outputs.prop == 'inject-update-email' }} ${{'Injection unsuccessful; email remains unaltered.'}}
-
-      # TO DO: Delete later
-      # Check for userUpdateId email changes in results file
+      # Error if emails don't match
       - name: "Compare current email to original"
-        if: ${{ steps.getEmail.outputs.prop ==  'inject-update-email' }}
-        run: echo "Injection unsuccessful; email remains unaltered:"" ${{ steps.getEmail.outputs.prop }} = ${{ 'inject-update-email' }}"
-
-      # TO DO: Delete later
-      # Emails don't match; display them with an error message for now
-      - name: "ERROR - Compare current email to original"
-        if: ${{ steps.getEmail.outputs.prop != 'inject-update-email' }}
-        run: echo "ERROR - Injection successful; email isn't the same:"" ${{ steps.getEmail.outputs.prop }} = ${{ 'inject-update-email' }}"
+        run: echo ${{ steps.getEmail.outputs.prop == 'inject-update-email' }} ${{'Injection unsuccessful; email remains unaltered.'}}
       
       # Remove test results file
       - name: 'Remove Test Results File'

--- a/.github/workflows/sql-injection-delete-users-userid.yml
+++ b/.github/workflows/sql-injection-delete-users-userid.yml
@@ -8,7 +8,7 @@ env:
   RESULT_FILE_PATH: ../../test/security/sql-injection/delete-users-userid.json
 
 jobs:
-  DELETE-test-case:
+  DELETE-user-test-case:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main

--- a/.github/workflows/sql-injection-delete-users-userid.yml
+++ b/.github/workflows/sql-injection-delete-users-userid.yml
@@ -5,7 +5,6 @@ on:
       - development
 env:
   NODE_VERSION: '10.x'
-  RESULT_FILE_PATH: ../../test/security/sql-injection/delete-users-userid.json
 jobs:
   DELETE-user-test-case:
     runs-on: ubuntu-latest
@@ -20,7 +19,7 @@ jobs:
         id: userDeleteId
         uses: notiz-dev/github-action-json-property@release
         with: 
-          path: env.RESULT_FILE_PATH
+          path: test/security/sql-injection/delete-users-userid.json
           prop_path: 'userId'
       # Create test user to update and write user json to result file
       - name: 'Create test user to update'
@@ -31,7 +30,7 @@ jobs:
         id: userUpdateId
         uses: notiz-dev/github-action-json-property@release
         with: 
-          path: env.RESULT_FILE_PATH
+          path: test/security/sql-injection/delete-users-userid.json
           prop_path: 'userId'  
       # Attempt update injection on email and update result file
       - name: "Delete user with userId ${{steps.userDeleteId.outputs.prop}}"
@@ -46,7 +45,7 @@ jobs:
         id: deletionCheck
         uses: notiz-dev/github-action-json-property@release
         with: 
-          path: env.RESULT_FILE_PATH
+          path: test/security/sql-injection/delete-users-userid.json
           prop_path: 'userId'
       # Check for userDeleteId in json result file
       - name: "User deletion confirmation"
@@ -60,7 +59,7 @@ jobs:
         id: getEmail
         uses: notiz-dev/github-action-json-property@release
         with: 
-          path: env.RESULT_FILE_PATH
+          path: test/security/sql-injection/delete-users-userid.json
           prop_path: 'email'
       # Use the output from above step
       - name: "Compare email to original"
@@ -70,4 +69,4 @@ jobs:
       - name: 'Remove Test Results File'
         uses: JesseTG/rm@v1.0.2
         with:
-          path: env.RESULT_FILE_PATH
+          path: test/security/sql-injection/delete-users-userid.json

--- a/.github/workflows/sql-injection-delete-users-userid.yml
+++ b/.github/workflows/sql-injection-delete-users-userid.yml
@@ -1,5 +1,4 @@
 name: SQL injection test for DELETE users/userid
-
 on:
   push:
     branches:
@@ -13,20 +12,62 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      # Test set up
-      - name: 'Create test user for delete injection test'
+      # Create test user to delete and write user json to result file
+      - name: 'Create test user to delete'
         run: |
           curl -v -X POST -d '{"firstName": "inject-del-fname", "lastName": "inject-del-lname", "email": "inject-del-email"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users > test/security/sql-injection/delete-users-userid.json
-      - name: 'Get userId'
-        id: userId
+      # Retrieve userId from json result file
+      - name: 'Get userId-to delete'
+        id: userDeleteId
+        uses: notiz-dev/github-action-json-property@release
+        with: 
+          path: env.RESULT_FILE_PATH
+          prop_path: 'userId'
+
+      # Create test user and write user json to result file
+      - name: 'Create test user to update'
+        run: |
+          curl -v -X POST -d '{"firstName": "inject-update-fname", "lastName": "inject-update-lname", "email": "inject-update-email"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users > test/security/sql-injection/delete-users-userid.json
+      # Retrieve userId from json result file
+      - name: 'Get userId-to update'
+        id: userUpdateId
         uses: notiz-dev/github-action-json-property@release
         with: 
           path: env.RESULT_FILE_PATH
           prop_path: 'userId'
 
 
+  
 
-      # Remove test file created
+      # Attempt delete injection on userUpdateId and update json result file
+      - name: "Delete user with userId ${{steps.userDeleteId.outputs.prop}}"
+        run: |
+          curl -v -X DELETE -d '{"userId": "'${{steps.userDeleteId.outputs.prop}}'); or 1=1; UPDATE users SET email='attacked email' WHERE userId='${{steps.userUpdateId.outputs.prop}}'; --"}' https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${{steps.userDeleteId.outputs.prop}} > test/security/sql-injection/delete-users-userid.json
+
+      # Check for userDeleteId in json result file
+      - name: 'Check for userDeleteId deletion'
+        id: deletionCheck
+        uses: notiz-dev/github-action-json-property@release
+        with: 
+          path: env.RESULT_FILE_PATH
+          prop_path: 'userId'
+
+      - name: "User deletion confirmation"
+        run: "Deleted user " ${{steps.deletionCheck.outputs.prop}}
+
+      # Check for userUpdateId email update in json result file
+      - name: 'Check for userUpdateteId email attack'
+        id: injectionCheck
+        uses: notiz-dev/github-action-json-property@release
+        with: 
+          path: env.RESULT_FILE_PATH
+          prop_path: 'email'
+
+      - name: "Email update injection confirmation"
+        run: "Email updated " ${{steps.injectionCheck.outputs.prop}}
+
+
+      # Remove test results file
       - name: 'Remove Test Results File'
         uses: JesseTG/rm@v1.0.2
         with:


### PR DESCRIPTION
Closes #200 

Creates GitHub action for SQL injection test for HTTP method DELETE to delete /users/{user_id} (from HttpTriggerAPIUsersId api)

**What it does:**
1. Create test users: one to delete and one to attempt an SQL injection. Retrieve the new userId's for both
2. Attempt DELETE and UPDATE injection
3. Check for injection attack success
**NOTE: Because of the known bug with GET requests and Redis caching for users/userId (described more in comments below) I currently (for testing purposes) have this test set to continue to run, but rather show an error message with the email values if the emails don't match. Once the bug is corrected, the test should be changed to fail in the case of email values not matching.**
4. Delete results file

**To test:**
I tested this task in a fork. (Screenshots to follow) 
![image](https://user-images.githubusercontent.com/13280802/110198438-51f7d780-7e07-11eb-886a-d87e56294468.png)


**Time Spent:**
| Date | Description | Time |
| ------------- | ------------- |------------- |
| 2/20 | Watch tutorials on SQL injection | 2 hrs |
| 2/22 |  SQL injection article and example research | 2 hrs |
| 2/26 |  Review class lecture | 2 hrs |
| 2/26 |  Code Development Attempt | 2 hrs |
| 3/1 |  Code Development | 1 hrs |
| 3/3 |  Code Development and Research Github Actions | 4 hrs |
|2/20- 3/4 |  Record keeping | 1 hrs |
|3/5 |  Troubleshooting and speak with Farhad | 1 hrs |