### PR TITLE
Action to Artillery test of /users/{user_id} Lamdba function and upload the Storage container 

### DIFF
--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -1,4 +1,4 @@
-name: Artillery test for Lambda users api
+name: Lambda users-id artillery test
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   art-aws-users-test:
-    name: Artillery Lambda Users test
+    name: Lambda users-id artillery test
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_PREFIX: "~/.npm-global"
@@ -22,8 +22,8 @@ jobs:
           check-latest: true
       - name: Install Artillery
         run: npm install -g artillery
-      - name: Run Artillery Test on Lamda Users API
-        run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_results.json ./test/artillery/artillery-user-id-lambda.yml
+      - name: Run the artillery-test on the users-is Lamda API
+        run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_id_results.json ./test/artillery/artillery-user-id-lambda.yml
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M-%S')"
@@ -36,7 +36,7 @@ jobs:
             az storage blob upload \
               -c artillery \
               -f ./test/results/lambda_users_${{ steps.date.outputs.date }}.json \
-              -n lambda_users_${{ steps.date.outputs.date }}.json \
+              -n lambda_users_id_${{ steps.date.outputs.date }}.json \
               --connection-string "${{ secrets.BLOB_STORAGE_CONNECTION_STRING }}"
 
 # name: Upload To Azure Blob Storage

--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -1,4 +1,4 @@
-name: Lambda users-id artillery test
+name: Lambda users-userid api
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   art-aws-users-test:
-    name: Lambda users-id artillery test
+    name: Artillery Lambda Users test
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_PREFIX: "~/.npm-global"
@@ -22,8 +22,8 @@ jobs:
           check-latest: true
       - name: Install Artillery
         run: npm install -g artillery
-      - name: Run the artillery-test on the users-is Lamda API
-        run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_id_results.json ./test/artillery/artillery-user-id-lambda.yml
+      - name: Run Artillery Test on Lamda Users API
+        run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_results.json ./test/artillery/artillery-user-id-lambda.yml
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M-%S')"
@@ -36,7 +36,7 @@ jobs:
             az storage blob upload \
               -c artillery \
               -f ./test/results/lambda_users_${{ steps.date.outputs.date }}.json \
-              -n lambda_users_id_${{ steps.date.outputs.date }}.json \
+              -n lambda_users_${{ steps.date.outputs.date }}.json \
               --connection-string "${{ secrets.BLOB_STORAGE_CONNECTION_STRING }}"
 
 # name: Upload To Azure Blob Storage

--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -5,6 +5,18 @@ on:
     branches:
       - development
 
+#   upload:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+#         with:
+#           source_dir: _dist
+#           container_name: www
+#           connection_string: ${{ secrets.ConnectionString }}
+#           extra_args: '--pattern *.tar.gz'
+#           sync: false
+
 jobs:
   art-aws-users-test:
     name: Artillery Lambda Users id test
@@ -24,25 +36,17 @@ jobs:
         run: npm install -g artillery
       - name: Artillery Test with Lamda Users ID API
         run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_results.json ./test/artillery/artillery-user-id-lambda.yml
+      - name: Grab current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M-%S')"
       - name: Rename results json
-        run: mv ./test/results/lambda_users_results.json ./test/results/lambda_users_${{ steps.outputs }}.json
+        run: mv ./test/results/lambda_users_results.json ./test/results/lambda_users_${{ steps.date.outputs.date }}.json
       - name: Upload report to Azure Blob Storage
         uses: azure/CLI@v1
         with:
           inlineScript: |
             az storage blob upload \
               -c artillery \
-              -f ./test/results/lambda_users_id_${{ steps.outputs }}.json \
-              -n lambda_users_id_${{ steps.outputs }}.json \
+              -f ./test/results/lambda_users_id_${{ steps.date.outputs.date }}.json \
+              -n lambda_users_id_${{ steps.date.outputs.date }}.json \
               --connection-string "${{ secrets.BLOB_STORAGE_CONNECTION_STRING }}"
-
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v2
-#       - uses: bacongobbler/azure-blob-storage-upload@v1.1.1
-#         with:
-#           source_dir: _dist
-#           container_name: www
-#           connection_string: ${{ secrets.ConnectionString }}
-#           extra_args: '--pattern *.tar.gz'
-#           sync: false

--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -22,7 +22,7 @@ jobs:
           check-latest: true
       - name: Install Artillery
         run: npm install -g artillery
-      - name: Run Artillery Test on Lamda Users ID API
+      - name: Artillery Test with Lamda Users ID API
         run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_results.json ./test/artillery/artillery-user-id-lambda.yml
       - name: Grab current date
         id: date

--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Artillery
         run: npm install -g artillery
       - name: Run Artillery Test on Lamda Users API
-        run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_results.json ./test/artillery/artillery-test-lambda-users.yml
+        run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_results.json ./test/artillery/artillery-user-id-lambda.yml
       - name: Get current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M-%S')"
@@ -38,3 +38,22 @@ jobs:
               -f ./test/results/lambda_users_${{ steps.date.outputs.date }}.json \
               -n lambda_users_${{ steps.date.outputs.date }}.json \
               --connection-string "${{ secrets.BLOB_STORAGE_CONNECTION_STRING }}"
+
+# name: Upload To Azure Blob Storage
+
+# on:
+#   push:
+#     branches:
+#       - master
+# jobs:
+#   upload:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+#         with:
+#           source_dir: _dist
+#           container_name: www
+#           connection_string: ${{ secrets.ConnectionString }}
+#           extra_args: '--pattern *.tar.gz'
+#           sync: false

--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -24,9 +24,6 @@ jobs:
         run: npm install -g artillery
       - name: Artillery Test with Lamda Users ID API
         run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_results.json ./test/artillery/artillery-user-id-lambda.yml
-      - name: Grab current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M-%S')"
       - name: Rename results json
         run: mv ./test/results/lambda_users_results.json ./test/results/lambda_users_${{ steps.date.outputs.date }}.json
       - name: Upload report to Azure Blob Storage
@@ -35,18 +32,10 @@ jobs:
           inlineScript: |
             az storage blob upload \
               -c artillery \
-              -f ./test/results/lambda_users_id_${{ steps.date.outputs.date }}.json \
-              -n lambda_users_id_${{ steps.date.outputs.date }}.json \
+              -f ./test/results/lambda_users_id_${{ steps.outputs }}.json \
+              -n lambda_users_id_${{ steps.outputs }}.json \
               --connection-string "${{ secrets.BLOB_STORAGE_CONNECTION_STRING }}"
 
-# name: Upload To Azure Blob Storage
-
-# on:
-#   push:
-#     branches:
-#       - master
-# jobs:
-#   upload:
 #     runs-on: ubuntu-latest
 #     steps:
 #       - uses: actions/checkout@v2

--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Artillery
         run: npm install -g artillery
       - name: Artillery Test with Lamda Users ID API
-        run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_id_results.json ./test/artillery/artillery-user-id-lambda.yml
+        run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_results.json ./test/artillery/artillery-user-id-lambda.yml
       - name: Grab current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M-%S')"

--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -35,8 +35,8 @@ jobs:
           inlineScript: |
             az storage blob upload \
               -c artillery \
-              -f ./test/results/lambda_users_${{ steps.date.outputs.date }}.json \
-              -n lambda_users_${{ steps.date.outputs.date }}.json \
+              -f ./test/results/lambda_users_id_${{ steps.date.outputs.date }}.json \
+              -n lambda_users_id_${{ steps.date.outputs.date }}.json \
               --connection-string "${{ secrets.BLOB_STORAGE_CONNECTION_STRING }}"
 
 # name: Upload To Azure Blob Storage

--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -5,18 +5,6 @@ on:
     branches:
       - development
 
-#   upload:
-#     runs-on: ubuntu-latest
-#     steps:
-#       - uses: actions/checkout@v2
-#       - uses: bacongobbler/azure-blob-storage-upload@v1.1.1
-#         with:
-#           source_dir: _dist
-#           container_name: www
-#           connection_string: ${{ secrets.ConnectionString }}
-#           extra_args: '--pattern *.tar.gz'
-#           sync: false
-
 jobs:
   art-aws-users-test:
     name: Artillery Lambda Users id test
@@ -47,6 +35,25 @@ jobs:
           inlineScript: |
             az storage blob upload \
               -c artillery \
-              -f ./test/results/lambda_users_id_${{ steps.date.outputs.date }}.json \
+              -f ./test/results/lambda_users_${{ steps.date.outputs.date }}.json \
               -n lambda_users_id_${{ steps.date.outputs.date }}.json \
               --connection-string "${{ secrets.BLOB_STORAGE_CONNECTION_STRING }}"
+
+# name: Upload To Azure Blob Storage
+
+# on:
+#   push:
+#     branches:
+#       - master
+# jobs:
+#   upload:
+#     runs-on: ubuntu-latest
+#     steps:
+#       - uses: actions/checkout@v2
+#       - uses: bacongobbler/azure-blob-storage-upload@v1.1.1
+#         with:
+#           source_dir: _dist
+#           container_name: www
+#           connection_string: ${{ secrets.ConnectionString }}
+#           extra_args: '--pattern *.tar.gz'
+#           sync: false

--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Artillery
         run: npm install -g artillery
       - name: Artillery Test with Lamda Users ID API
-        run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_results.json ./test/artillery/artillery-user-id-lambda.yml
+        run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_id_results.json ./test/artillery/artillery-user-id-lambda.yml
       - name: Grab current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M-%S')"

--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -1,4 +1,4 @@
-name: Artillery-Test serverless-artillery-action-users-id-Lambda function
+name: Lambda users-userid api
 
 on:
   push:

--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Artillery Test with Lamda Users ID API
         run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_results.json ./test/artillery/artillery-user-id-lambda.yml
       - name: Rename results json
-        run: mv ./test/results/lambda_users_results.json ./test/results/lambda_users_${{ steps.date.outputs.date }}.json
+        run: mv ./test/results/lambda_users_results.json ./test/results/lambda_users_${{ steps.outputs }}.json
       - name: Upload report to Azure Blob Storage
         uses: azure/CLI@v1
         with:

--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -1,0 +1,40 @@
+name: Artillery test for Lambda users api
+
+on:
+  push:
+    branches:
+      - development
+
+jobs:
+  art-aws-users-test:
+    name: Artillery Lambda Users test
+    runs-on: ubuntu-latest
+    env:
+      NPM_CONFIG_PREFIX: "~/.npm-global"
+      NODE_VERSION: "14"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          check-latest: true
+      - name: Install Artillery
+        run: npm install -g artillery
+      - name: Run Artillery Test on Lamda Users API
+        run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_results.json ./test/artillery/artillery-test-lambda-users.yml
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M-%S')"
+      - name: Rename results json
+        run: mv ./test/results/lambda_users_results.json ./test/results/lambda_users_${{ steps.date.outputs.date }}.json
+      - name: Upload report to Azure Blob Storage
+        uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az storage blob upload \
+              -c artillery \
+              -f ./test/results/lambda_users_${{ steps.date.outputs.date }}.json \
+              -n lambda_users_${{ steps.date.outputs.date }}.json \
+              --connection-string "${{ secrets.BLOB_STORAGE_CONNECTION_STRING }}"

--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -7,24 +7,24 @@ on:
 
 jobs:
   art-aws-users-test:
-    name: Artillery Lambda Users test
+    name: Artillery Lambda Users id test
     runs-on: ubuntu-latest
     env:
       NPM_CONFIG_PREFIX: "~/.npm-global"
       NODE_VERSION: "14"
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Node.js
+      - name: Setup Node
         uses: actions/setup-node@v2
         with:
           node-version: ${{ env.NODE_VERSION }}
           check-latest: true
       - name: Install Artillery
         run: npm install -g artillery
-      - name: Run Artillery Test on Lamda Users API
+      - name: Run Artillery Test on Lamda Users ID API
         run: ~/.npm-global/bin/artillery run --output ./test/results/lambda_users_results.json ./test/artillery/artillery-user-id-lambda.yml
-      - name: Get current date
+      - name: Grab current date
         id: date
         run: echo "::set-output name=date::$(date +'%Y-%m-%d-%H-%M-%S')"
       - name: Rename results json

--- a/.github/workflows/artillery-users-id-lambda.yml
+++ b/.github/workflows/artillery-users-id-lambda.yml
@@ -1,4 +1,4 @@
-name: Lambda users-userid api
+name: Artillery-Test serverless-artillery-action-users-id-Lambda function
 
 on:
   push:

--- a/test/artillery/artillery-user-id-lambda.yml
+++ b/test/artillery/artillery-user-id-lambda.yml
@@ -1,5 +1,6 @@
 config:
-
+  payload:
+    path: "./payloads/usersIdPayload.csv"
     fields:
       - "firstName"
       - "lastName"
@@ -7,8 +8,8 @@ config:
     skipHeader: true
   target: "https://mchfd7t6l4.execute-api.us-west-2.amazonaws.com"
   phases:
-    -
-      duration: 100
+    - name: Start
+      duration: 300
       arrivalRate: 10
 scenarios:
   - flow:

--- a/test/artillery/artillery-user-id-lambda.yml
+++ b/test/artillery/artillery-user-id-lambda.yml
@@ -1,6 +1,5 @@
 config:
-  payload:
-    path: "./payloads/usersIdPayload.csv"
+
     fields:
       - "firstName"
       - "lastName"
@@ -8,21 +7,16 @@ config:
     skipHeader: true
   target: "https://mchfd7t6l4.execute-api.us-west-2.amazonaws.com"
   phases:
-    - name: Warm Up
-      duration: 60
-      arrivalRate: 2
-    - name: Ramp up
-      duration: 120
-      arrivalRate: 5
-      rampTo: 60
-
+    -
+      duration: 100
+      arrivalRate: 10
 scenarios:
   - flow:
       - post:
-          url: "/users/5"
+          url: "/users/1"
           json:
             firstName: "{{ firstName }}"
             lastName: "{{ lastName }}"
             email: "{{ email }}"
       - get:
-          url: "/users/5"
+          url: "/users/1"

--- a/test/artillery/artillery-user-id-lambda.yml
+++ b/test/artillery/artillery-user-id-lambda.yml
@@ -1,0 +1,28 @@
+config:
+  payload:
+    path: "./payloads/usersIdPayload.csv"
+    fields:
+      - "firstName"
+      - "lastName"
+      - "email"
+    skipHeader: true
+  target: "https://mchfd7t6l4.execute-api.us-west-2.amazonaws.com"
+  phases:
+    - name: Warm Up
+      duration: 60
+      arrivalRate: 2
+    - name: Ramp up
+      duration: 120
+      arrivalRate: 5
+      rampTo: 60
+
+scenarios:
+  - flow:
+      - post:
+          url: "/users/5"
+          json:
+            firstName: "{{ firstName }}"
+            lastName: "{{ lastName }}"
+            email: "{{ email }}"
+      - get:
+          url: "/users/5"

--- a/ui/react-ui/src/components/app/App.js
+++ b/ui/react-ui/src/components/app/App.js
@@ -32,7 +32,7 @@ function App() {
         <Route exact path='/reports/userId' component={userIdReport}/>
         <Route exact path='/reports/users' component={usersReport}/>
         <Route exact path='/reports/tasks' component={TasksReport}/>
-         
+            {/* Test results routes */}
 
         {/* Create user + task */}
         <Route exact path='/create' component={Create} />

--- a/ui/react-ui/src/components/app/App.js
+++ b/ui/react-ui/src/components/app/App.js
@@ -10,6 +10,8 @@ import userIdReport from '../routes/reports/userIdReport/UserIdReport';
 import usersReport from '../routes/reports/usersReport/UserReport';
 import TasksReport from '../routes/reports/userIdReport/UserIdTasksReport'
 import Create from '../routes/create/Create';
+
+
  
 function App() {
   return (
@@ -30,6 +32,7 @@ function App() {
         <Route exact path='/reports/userId' component={userIdReport}/>
         <Route exact path='/reports/users' component={usersReport}/>
         <Route exact path='/reports/tasks' component={TasksReport}/>
+           {/* Test results routes */}
 
         {/* Create user + task */}
         <Route exact path='/create' component={Create} />

--- a/ui/react-ui/src/components/app/App.js
+++ b/ui/react-ui/src/components/app/App.js
@@ -32,8 +32,8 @@ function App() {
         <Route exact path='/reports/userId' component={userIdReport}/>
         <Route exact path='/reports/users' component={usersReport}/>
         <Route exact path='/reports/tasks' component={TasksReport}/>
-            {/* Test results routes */}
-
+          
+          
         {/* Create user + task */}
         <Route exact path='/create' component={Create} />
       </Router>

--- a/ui/react-ui/src/components/app/App.js
+++ b/ui/react-ui/src/components/app/App.js
@@ -32,7 +32,7 @@ function App() {
         <Route exact path='/reports/userId' component={userIdReport}/>
         <Route exact path='/reports/users' component={usersReport}/>
         <Route exact path='/reports/tasks' component={TasksReport}/>
-           {/* Test results routes */}
+         
 
         {/* Create user + task */}
         <Route exact path='/create' component={Create} />


### PR DESCRIPTION
closes #262



This feature tests the /users/{user_id} artillery with the Lambda API function in order to upload the results to a storage container in Azure so the results can be downloaded and viewed from the artillery container in the nsc-rg-dev-usw2-thursday resource group.

## Testing

- Either fork this Repo or make a new branch in the Repo that this feature is in.
- Make a change and push to the development branch. 
- You might  need the connection string code from the keys page in our Azure's nsc-rg-dev-usw2-thursday resource group but it is still possible to test this without it.
- The results will show in the artillery folder in our Azure storage container


<img width="777" alt="Screen Shot 2021-03-18 at 11 57 26 PM" src="https://user-images.githubusercontent.com/57120136/111746140-dbb59500-884a-11eb-8e3a-c447a8cdf9b7.png">


**Troubleshooting Tips**
If there is any trouble testing this make sure to check each step of the Github Action Workflow and you will find were the test failed.



<img width="1217" alt="Screen Shot 2021-03-18 at 11 55 13 PM" src="https://user-images.githubusercontent.com/57120136/111745732-40bcbb00-884a-11eb-8b0a-c15cd1a3fc72.png">

Date | Activity | Time Spent
-- | -- | --
3/07/2021|Research Azure Storage containers with GH actions |3 hours
3/10/2021|Create a test workflow to send JSON  |2 hours
3/15/2021|Add artillery test to the workflow | 2 hours 
3/17/2021|Upload results to the right storage blob | 3 hours 
3/18/2021|Fix bugs | 4 hours 