### PR TITLE
Add paging to users/{user_ID}/tasks

### DIFF
--- a/ui/react-ui/src/components/app/App.js
+++ b/ui/react-ui/src/components/app/App.js
@@ -1,6 +1,6 @@
 import './App.css';
 import {BrowserRouter as Router, Route,} from 'react-router-dom'; 
-import UserTasks from '../routes/userTasks/UserTasks.js';
+import UserTasks from '../routes/userTasks/UserTasksPaginated.js';
 import Home from '../routes/home/Home.js';
 import User from '../routes/userid/userid.js';
 import Users from '../routes/users/UsersPaginated';

--- a/ui/react-ui/src/components/routes/userTasks/UserTasks.js
+++ b/ui/react-ui/src/components/routes/userTasks/UserTasks.js
@@ -22,11 +22,13 @@ const UserTasks = () => {
     .catch((error) => console.error(error))
   }, [userId]);
 
+  /*
   function deleteTask(taskId){
     const messages = this.state.messages.filter((_, index) => index !== i)
     this.setState({ messages });
 
   }
+  */
 
   return (
     <>
@@ -37,7 +39,7 @@ const UserTasks = () => {
         ? <BootstrapTable heatherItems={Object.keys(userTasks[2][0])} rows={userTasks[2]} /> 
         : <h3>User {userId} Tasks Not Found</h3>
       }
-      <button onClick={() => this.deleteTask()}>Delete Task</button>
+      {/* <button onClick={() => this.deleteTask()}>Delete Task</button> */}
       </Container>
     </>
   )

--- a/ui/react-ui/src/components/routes/userTasks/UserTasksPaginated.js
+++ b/ui/react-ui/src/components/routes/userTasks/UserTasksPaginated.js
@@ -1,9 +1,9 @@
 import React, {useState, useEffect} from 'react';
 import {useParams} from 'react-router-dom';
+import BackButton from '../../bootstrapBackButton/BootstrapBackButton'
 import BootstrapTable from 'react-bootstrap-table-next';
 import paginationFactory from 'react-bootstrap-table2-paginator'
 import * as ReactBootStrap from 'react-bootstrap';
-import { fetchSetTblState } from '../../../utils';
 import axios from 'axios';
 
 const UserTasksPaginated = () => {
@@ -21,8 +21,17 @@ const UserTasksPaginated = () => {
         {dataField: "completedDate", text: "Date Completed"}
     ]
 
+    // TODO:
+    // Add options to delete a task
+    // sort of present in original UserTasks.js but didn't really work
+
     const getData = async (userId)=>{
         try{
+            /*
+             * I wanted to use the fetchTableState from ../../utils
+             * But it just returned the data in a really unhelpful way with an incorrect
+             * "title" and "subtitle" tacked onto the front  
+             */
             const data = await axios.get(
                 `https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${userId}/tasks`
             );
@@ -38,8 +47,12 @@ const UserTasksPaginated = () => {
         setLoading(true);
     }, [userId]);
 
+    // TODO:
+    // Table spacing is bad in narrow windows
+
     return (
         <div className="pagination">
+            <div><BackButton /></div>
             {loading
                 ?(
                     <div className="table-wrapper">
@@ -49,6 +62,7 @@ const UserTasksPaginated = () => {
                             keyField="taskId"
                             data={userTasks}
                             columns={columns}
+                            pagination={paginationFactory()}
                         />
                     </div>
                 ): (<ReactBootStrap.Spinner animation="border" />)}

--- a/ui/react-ui/src/components/routes/userTasks/UserTasksPaginated.js
+++ b/ui/react-ui/src/components/routes/userTasks/UserTasksPaginated.js
@@ -1,0 +1,32 @@
+import React, {useState, useEffect} from 'react';
+import {useParams} from 'react-router-dom';
+import BootstrapTable from 'react-bootstrap-table-next';
+import paginationFactory from 'react-bootstrap-table2-paginator'
+import * as ReactBootStrap from 'react-bootstrap';
+import { fetchSetTblState } from '../../../utils';
+
+const UserTasksPaginated = () => {
+    let [userTasks, setUserTasks] = useState([]);
+    let [loading, setLoading] = useState(false);
+    let {userId} = useParams();
+
+    useEffect(() => {
+        try{
+            const response = fetchSetTblState(`users/${userId}/tasks`, setUserTasks)
+            setLoading(true)
+        } catch (error) {
+            console.error(error);
+        }
+    }, [userId]);
+
+    return (
+        <div className="pagination">
+            {loading
+                ?(
+                    <div><pre>{JSON.stringify(userTasks, null, 5)}</pre></div>
+                ): (<ReactBootStrap.Spinner animation="border" />)}
+        </div>
+    )
+}
+
+export default UserTasksPaginated;

--- a/ui/react-ui/src/components/routes/userTasks/UserTasksPaginated.js
+++ b/ui/react-ui/src/components/routes/userTasks/UserTasksPaginated.js
@@ -4,26 +4,53 @@ import BootstrapTable from 'react-bootstrap-table-next';
 import paginationFactory from 'react-bootstrap-table2-paginator'
 import * as ReactBootStrap from 'react-bootstrap';
 import { fetchSetTblState } from '../../../utils';
+import axios from 'axios';
 
 const UserTasksPaginated = () => {
     let [userTasks, setUserTasks] = useState([]);
     let [loading, setLoading] = useState(false);
     let {userId} = useParams();
 
-    useEffect(() => {
+    const columns = [
+        {dataField: "taskId", text: "Task ID"},
+        {dataField: "title", text: "Task"},
+        {dataField: "description", text: "Description"},
+        {dataField: "createdDate", text: "Date Created"},
+        {dataField: "dueDate", text: "Due Date"},
+        {dataField: "completed", text: "Is Complete"},
+        {dataField: "completedDate", text: "Date Completed"}
+    ]
+
+    const getData = async (userId)=>{
         try{
-            const response = fetchSetTblState(`users/${userId}/tasks`, setUserTasks)
-            setLoading(true)
+            const data = await axios.get(
+                `https://nsc-fun-dev-usw2-thursday.azurewebsites.net/api/users/${userId}/tasks`
+            );
+            console.log(data);
+            setUserTasks(data.data);
         } catch (error) {
             console.error(error);
         }
+    }
+
+    useEffect(() => {
+        getData(userId);
+        setLoading(true);
     }, [userId]);
 
     return (
         <div className="pagination">
             {loading
                 ?(
-                    <div><pre>{JSON.stringify(userTasks, null, 5)}</pre></div>
+                    <div className="table-wrapper">
+                        <BootstrapTable
+                            rowStyle = {{backgroundColor: 'white'}}
+                            className="table"
+                            keyField="taskId"
+                            data={userTasks}
+                            columns={columns}
+                        />
+                    </div>
                 ): (<ReactBootStrap.Spinner animation="border" />)}
         </div>
     )


### PR DESCRIPTION
Closes: https://github.com/North-Seattle-College/ad440-winter2021-thursday-repo/issues/319

Bootstrap Tables have built-in pagination, looks like, so I rewrote the UserTasks.js React UI into UserTasksPaginated.js following a similar style to UsersPaginated.js.
![image](https://user-images.githubusercontent.com/57050171/112424603-f4fa8d80-8cf1-11eb-8cee-b899e8d0d824.png)
-----
### For testing on local machines:
- Pull down the branch from my fork
- Open the fork folder and type `cmd` in the explorer bar
- `cd ui/react-ui`
- `npm install`
- `npm start`
     - Or otherwise get a command line and start the react app on your local machine to taste
- Enter a user ID into the /users/_______/tasks search bar
     - 2 is good
- Underneath the table you will see the paginationFactory

-----
### Possible improvements:
- Table spacing looks bad on narrow windows
- No "mark completed" option
- Possibly reworking utils.js 's `fetchSetTblState()` so it returns a nicer JSON of the data and removal of coded column names in UsersPaginated and UserTasksPaginated