### PR TITLE
Added function to count how long it takes to load a page 40 times

### DIFF
--- a/test/ui/capturetimetaskid.js
+++ b/test/ui/capturetimetaskid.js
@@ -5,6 +5,8 @@ let totalSeconds = 0;
 let loadtime=0;
 
 (async() =>{
+    var startDate = new Date();
+    var startTime = startDate.getTime();
     const ENV_PAGE = "https://nscstrdevusw2thucommon.z5.web.core.windows.net/#/users/2/tasks/1";
     const browser = await puppeteer.launch()
     for(var i = 0; i< NUM_TIMES; i++){
@@ -12,7 +14,9 @@ let loadtime=0;
         console.log(`Opening Page. Heading for target page...`);
         await webpage.goto(ENV_PAGE)
         await webpage.setCacheEnabled(false)
-        loadtime =PerformanceNavigationTiming.loadEventEnd - PerformanceNavigationTiming.loadEventStart;
+            var endDate = new Date();
+        loadtime = endDate.getTime-startTime;
+        console.log(`Time to load page was: ${loadtime}`)
         await webpage.close();    
         }
         console.log(`The average time it took to load the page 40 times: ${totalSeconds/NUM_TIMES}`)

--- a/test/ui/capturetimetaskid.js
+++ b/test/ui/capturetimetaskid.js
@@ -1,8 +1,8 @@
 const puppeteer = require('puppeteer')
 
-NUM_TIMES=40
-totalSeconds = 0
-loadtime=0
+var NUM_TIMES=40
+var totalSeconds = 0
+var loadtime=0
 
 const  pageMetrics = async() =>{
     const browser = await puppeteer.launch({headless: false})

--- a/test/ui/capturetimetaskid.js
+++ b/test/ui/capturetimetaskid.js
@@ -3,9 +3,9 @@ const puppeteer = require('puppeteer')
 var NUM_TIMES=40;
 
 (async() =>{
-    var startDate = new Date();
-    var startTime = startDate.getTime();
-    var totalSeconds = 0;
+    let startDate = new Date();
+    let startTime = startDate.getTime();
+    let totalSeconds = 0;
     //var totalSeconds = 0;
     const ENV_PAGE = "https://nscstrdevusw2thucommon.z5.web.core.windows.net/#/users/2/tasks/1";
     const browser = await puppeteer.launch()

--- a/test/ui/capturetimetaskid.js
+++ b/test/ui/capturetimetaskid.js
@@ -11,10 +11,9 @@ const  pageMetrics = async() =>{
     ENV_PAGE = os.environ['target_website']
     await webpage.goto(ENV_PAGE)
     const pagePerf = await page.evaluate(_=>{
-        const{loadEventEnd, navigationStart}=PerformanceTiming
-        return({loadtime=loadEventEnd-navigationStart
-        })
-        
+            loadtime =PerformanceNavigationTiming.loadEventEnd - PerformanceNavigationTiming.loadEventStart
+            return loadtime
+       
     })
     totalSeconds+=pagePerf.loadtime
     console.log(`Page Load took: ${pagePerf.loadtime}ms`)

--- a/test/ui/capturetimetaskid.js
+++ b/test/ui/capturetimetaskid.js
@@ -1,28 +1,24 @@
 const puppeteer = require('puppeteer')
 
 var NUM_TIMES=40;
-const ENV_PAGE = `https://nscstrdevusw2thucommon.z5.web.core.windows.net/#/users/2/tasks/1`;
 let totalSeconds = 0;
 let loadtime=0;
 
-const  pageMetrics = async() =>{
-    const browser = await puppeteer.launch({headless: false})
-    const webpage = await browser.newPage()
-    await webpage.setCacheEnabled([False])
-    ENV_PAGE = os.environ['target_website']
-    await webpage.goto(ENV_PAGE)
-    const pagePerf = await page.evaluate(_=>{
-            loadtime =PerformanceNavigationTiming.loadEventEnd - PerformanceNavigationTiming.loadEventStart
-            return loadtime
-       
-    })
-    totalSeconds+=pagePerf.loadtime
-    console.log(`Page Load took: ${pagePerf.loadtime}ms`)
-    await webpage.close()
-}
+(async() =>{
+    const ENV_PAGE = "https://nscstrdevusw2thucommon.z5.web.core.windows.net/#/users/2/tasks/1";
+    const browser = await puppeteer.launch()
+    for(var i = 0; i< NUM_TIMES; i++){
+        const webpage = await browser.newPage();
+        console.log(`Opening Page. Heading for target page...`);
+        await webpage.goto(ENV_PAGE)
+        await webpage.setCacheEnabled(false)
+        loadtime =PerformanceNavigationTiming.loadEventEnd - PerformanceNavigationTiming.loadEventStart;
+        await webpage.close();    
+        }
+        console.log(`The average time it took to load the page 40 times: ${totalSeconds/NUM_TIMES}`)
+    })().catch(err => console.log(err));
+    
+    
+    
 
-for(var i = 0; i <NUM_TIMES; i++){
-    pageMetrics();
 
-}
-console.log(`The average time it took to load the page 40 times: ${totalSeconds/NUM_TIMES}`)

--- a/test/ui/capturetimetaskid.js
+++ b/test/ui/capturetimetaskid.js
@@ -1,8 +1,9 @@
 const puppeteer = require('puppeteer')
 
-var NUM_TIMES=40
-var totalSeconds = 0
-var loadtime=0
+var NUM_TIMES=40;
+const ENV_PAGE = `https://nscstrdevusw2thucommon.z5.web.core.windows.net/#/users/2/tasks/1`;
+let totalSeconds = 0;
+let loadtime=0;
 
 const  pageMetrics = async() =>{
     const browser = await puppeteer.launch({headless: false})
@@ -21,7 +22,7 @@ const  pageMetrics = async() =>{
 }
 
 for(var i = 0; i <NUM_TIMES; i++){
-    pageMetrics()
+    pageMetrics();
 
 }
 console.log(`The average time it took to load the page 40 times: ${totalSeconds/NUM_TIMES}`)

--- a/test/ui/capturetimetaskid.js
+++ b/test/ui/capturetimetaskid.js
@@ -8,7 +8,7 @@ var NUM_TIMES=40;
     let totalSeconds = 0;
     //var totalSeconds = 0;
     const ENV_PAGE = "https://nscstrdevusw2thucommon.z5.web.core.windows.net/#/users/2/tasks/1";
-    const browser = await puppeteer.launch()
+    const browser = await puppeteer.launch({headless:false})
     for(var i = 0; i< NUM_TIMES; i++){
         const webpage = await browser.newPage();
         console.log(`Opening Page. Heading for target page...`);

--- a/test/ui/capturetimetaskid.js
+++ b/test/ui/capturetimetaskid.js
@@ -6,6 +6,7 @@ var NUM_TIMES=40;
     var startDate = new Date();
     var startTime = startDate.getTime();
     var totalSeconds = 0;
+    //var totalSeconds = 0;
     const ENV_PAGE = "https://nscstrdevusw2thucommon.z5.web.core.windows.net/#/users/2/tasks/1";
     const browser = await puppeteer.launch()
     for(var i = 0; i< NUM_TIMES; i++){
@@ -14,14 +15,14 @@ var NUM_TIMES=40;
         await webpage.goto(ENV_PAGE)
         await webpage.setCacheEnabled(false)
             var endDate = new Date();
-        var loadtime = endDate.getTime-startTime;
-        console.log(`Time to load page was: ${loadtime}`)
+        var loadtime = endDate.getTime()-startTime;
+        console.log(`Time to load page was: ${loadtime}ms`)
         totalSeconds = totalSeconds + loadtime
         //Resets the startTime for next page loading
         startTime = new Date()
         await webpage.close();    
         }
-        console.log(`The average time it took to load the page 40 times: ${totalSeconds/NUM_TIMES}`)
+        console.log(`The average time it took to load the page 40 times: ${(totalSeconds/NUM_TIMES)}`)
     })().catch(err => console.log(err));
     
     

--- a/test/ui/capturetimetaskid.js
+++ b/test/ui/capturetimetaskid.js
@@ -16,6 +16,9 @@ var NUM_TIMES=40;
             var endDate = new Date();
         var loadtime = endDate.getTime-startTime;
         console.log(`Time to load page was: ${loadtime}`)
+        totalSeconds = totalSeconds + loadtime
+        //Resets the startTime for next page loading
+        startTime = new Date()
         await webpage.close();    
         }
         console.log(`The average time it took to load the page 40 times: ${totalSeconds/NUM_TIMES}`)

--- a/test/ui/capturetimetaskid.js
+++ b/test/ui/capturetimetaskid.js
@@ -1,12 +1,11 @@
 const puppeteer = require('puppeteer')
 
 var NUM_TIMES=40;
-let totalSeconds = 0;
-let loadtime=0;
 
 (async() =>{
     var startDate = new Date();
     var startTime = startDate.getTime();
+    var totalSeconds = 0;
     const ENV_PAGE = "https://nscstrdevusw2thucommon.z5.web.core.windows.net/#/users/2/tasks/1";
     const browser = await puppeteer.launch()
     for(var i = 0; i< NUM_TIMES; i++){
@@ -15,7 +14,7 @@ let loadtime=0;
         await webpage.goto(ENV_PAGE)
         await webpage.setCacheEnabled(false)
             var endDate = new Date();
-        loadtime = endDate.getTime-startTime;
+        var loadtime = endDate.getTime-startTime;
         console.log(`Time to load page was: ${loadtime}`)
         await webpage.close();    
         }

--- a/test/ui/capturetimetaskid.js
+++ b/test/ui/capturetimetaskid.js
@@ -7,6 +7,7 @@ loadtime=0
 const  pageMetrics = async() =>{
     const browser = await puppeteer.launch({headless: false})
     const webpage = await browser.newPage()
+    await webpage.setCacheEnabled([False])
     ENV_PAGE = os.environ['target_website']
     await webpage.goto(ENV_PAGE)
     const pagePerf = await page.evaluate(_=>{
@@ -24,4 +25,4 @@ for(var i = 0; i <NUM_TIMES; i++){
     pageMetrics()
 
 }
-console.log(`The average time it took to load the page 40 times: ${totalSeconds/40}`)
+console.log(`The average time it took to load the page 40 times: ${totalSeconds/NUM_TIMES}`)

--- a/test/ui/capturetimetaskid.js
+++ b/test/ui/capturetimetaskid.js
@@ -1,0 +1,27 @@
+const puppeteer = require('puppeteer')
+
+NUM_TIMES=40
+totalSeconds = 0
+loadtime=0
+
+const  pageMetrics = async() =>{
+    const browser = await puppeteer.launch({headless: false})
+    const webpage = await browser.newPage()
+    ENV_PAGE = os.environ['target_website']
+    await webpage.goto(ENV_PAGE)
+    const pagePerf = await page.evaluate(_=>{
+        const{loadEventEnd, navigationStart}=PerformanceTiming
+        return({loadtime=loadEventEnd-navigationStart
+        })
+        
+    })
+    totalSeconds+=pagePerf.loadtime
+    console.log(`Page Load took: ${pagePerf.loadtime}ms`)
+    await webpage.close()
+}
+
+for(var i = 0; i <NUM_TIMES; i++){
+    pageMetrics()
+
+}
+console.log(`The average time it took to load the page 40 times: ${totalSeconds/40}`)

--- a/test/ui/capturetimetaskid.js
+++ b/test/ui/capturetimetaskid.js
@@ -6,7 +6,6 @@ var NUM_TIMES=40;
     let startDate = new Date();
     let startTime = startDate.getTime();
     let totalSeconds = 0;
-    //var totalSeconds = 0;
     const ENV_PAGE = "https://nscstrdevusw2thucommon.z5.web.core.windows.net/#/users/2/tasks/1";
     const browser = await puppeteer.launch({headless:false})
     for(var i = 0; i< NUM_TIMES; i++){
@@ -14,15 +13,15 @@ var NUM_TIMES=40;
         console.log(`Opening Page. Heading for target page...`);
         await webpage.goto(ENV_PAGE)
         await webpage.setCacheEnabled(false)
-            var endDate = new Date();
-        var loadtime = endDate.getTime()-startTime;
+            let endDate = new Date();
+        var loadtime = endDate.getTime()-startTime
         console.log(`Time to load page was: ${loadtime}ms`)
         totalSeconds = totalSeconds + loadtime
         //Resets the startTime for next page loading
         startTime = new Date()
         await webpage.close();    
         }
-        console.log(`The average time it took to load the page 40 times: ${(totalSeconds/NUM_TIMES)}`)
+        console.log(`The average time it took to load the page 40 times: ${(totalSeconds/NUM_TIMES)}ms`)
     })().catch(err => console.log(err));
     
     


### PR DESCRIPTION
Closes #293 

**What this PR does:**
This function will not only count how long it will take for a page at the endpoint user/{user_id}/tasks/{task_id} to load, but it will load a page 40 times, counting up the seconds as it goes.  The console will print the average load time.  Caching code is forthcoming

**How to test the code (I used cmd on this one):**
1.) Navigate to test/ui
2.) Before starting, make sure you type npm install to load dependencies/whatever is needed.
3.) Type node capturetimetaskid.js
4.) You should be able to see 40 lines of output stating how long it takes to load the page at every iteration.  When the program stops running, you should be able to see the average time it took to load the page 40 times. 